### PR TITLE
Add tests for CRD's, check that helm IF statements are skipped, and l…

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,42 @@
+name: Lint on Pull Request
+
+# Controls when the action will run.
+on:
+  # Triggers the workflow on pull request events
+  pull_request:
+    branches: [ main, release-* ]
+  
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Add permissions for the workflow
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  lint:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # 1. Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      # 2. Sets up Python environment for the make command
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11' # Use a recent Python 3 version
+
+      # 3. Install system dependencies
+      - name: Install System Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y git curl
+
+      # 4. Run the make lint command
+      - name: Run Lint
+        run: make lint 

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -1,0 +1,53 @@
+name: Test on Pull Request
+
+# Controls when the action will run.
+on:
+  # Triggers the workflow on pull request events
+  pull_request:
+    branches: [ main, release-* ]
+  
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Add permissions for the workflow
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  test:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # 1. Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      # 2. Sets up Python environment for the make command
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11' # Use a recent Python 3 version
+
+      # 3. Install system dependencies
+      - name: Install System Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y git curl
+
+      # 4. Run the make test command
+      - name: Run Tests
+        run: make test
+        
+      # 5. Optional: Upload test results as artifacts (if you have test reports)
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: |
+            api-docs/
+            *.log
+          retention-days: 7 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ FORCE_DOWNLOAD ?= false
 deps: ensure-gen-api-docs
 	@which python3 > /dev/null || (echo "Python3 not found. Attempting to install..." && (command -v apt-get >/dev/null 2>&1 && sudo apt-get update && sudo apt-get install -y python3) || (command -v yum >/dev/null 2>&1 && sudo yum install -y python3) || (command -v brew >/dev/null 2>&1 && brew install python3) || (echo "Automatic install failed. Please install Python3 manually." && exit 1))
 	@python3 -c "import yaml" 2>/dev/null || (echo "PyYAML not found. Installing..." && python3 -m pip install --user pyyaml)
+	@python3 -c "import flake8" 2>/dev/null || (echo "Flake8 not found. Installing..." && python3 -m pip install --user flake8)
 	@which curl > /dev/null || (echo "Curl not found. Attempting to install..." && (command -v apt-get >/dev/null 2>&1 && sudo apt-get update && sudo apt-get install -y curl) || (command -v yum >/dev/null 2>&1 && sudo yum install -y curl) || (command -v brew >/dev/null 2>&1 && brew install curl) || (echo "Automatic install failed. Please install Curl manually." && exit 1))
 	@which git > /dev/null || (echo "Git not found. Attempting to install..." && (command -v apt-get >/dev/null 2>&1 && sudo apt-get update && sudo apt-get install -y git) || (command -v yum >/dev/null 2>&1 && sudo yum install -y git) || (command -v brew >/dev/null 2>&1 && brew install git) || (echo "Automatic install failed. Please install Git manually." && exit 1))
 
@@ -50,3 +51,51 @@ gen-api-docs: setup
 .PHONY: gen-api-docs-core
 gen-api-docs-core: setup-core gen-api-docs remove-core-crds
 	echo "API docs generated successfully"
+
+# Test targets
+.PHONY: test
+#test: test-crd-import test-helm-template-removal test-integration
+test: test-crd-import test-helm-template-removal test-clean
+	@echo "✅ All tests passed!"
+
+.PHONY: lint
+lint: deps
+	@echo "Running Python lint tests..."
+	@python3 -m flake8 cmd/ tests/ --max-line-length=120 --ignore=E501,W503 --exclude=__pycache__
+
+.PHONY: test-crd-import
+test-crd-import: deps
+	@echo "Running CRD import tests..."
+	@python3 tests/run_tests.py --pattern test_crd_import.py
+
+.PHONY: test-helm-template-removal
+test-helm-template-removal: deps
+	@echo "Running Helm template removal tests..."
+	@python3 tests/run_tests.py --pattern test_helm_template_removal.py
+
+.PHONY: test-integration
+test-integration: deps
+	@echo "Running integration tests..."
+	@python3 tests/run_tests.py --pattern test_integration.py
+
+.PHONY: test-verbose
+test-verbose: deps
+	@echo "Running all tests with verbose output..."
+	@python3 tests/run_tests.py --verbose
+
+.PHONY: test-clean
+test-clean:
+	@echo "Cleaning up test artifacts..."
+	@find . -name "*.pyc" -delete
+	@find . -name "__pycache__" -type d -exec rm -rf {} + 2>/dev/null || true
+	@rm -rf api-docs
+
+# Development targets
+.PHONY: dev-test
+dev-test: test-clean test
+	@echo "Development test cycle completed"
+
+.PHONY: validate
+validate: test gen-api-docs
+	@echo "✅ Validation completed - all tests passed and API docs generated successfully"
+

--- a/cmd/gen-api-docs.py
+++ b/cmd/gen-api-docs.py
@@ -5,13 +5,13 @@
 import os
 import re
 import yaml
-from collections import defaultdict
 
 # List of folder names to ignore during file search
-IGNORED_FOLDERS = ['vendor', '.github', '.git', 'hack']
+IGNORED_FOLDERS = ['vendor', '.github', '.git', 'hack', 'tests']
 
 # Global search directory
 search_dir = '.'
+
 
 def is_primitive(go_type):
     primitives = {'string', 'int', 'int32', 'int64', 'float32', 'float64', 'bool', 'byte', 'rune', 'uint', 'uint32', 'uint64', 'map', '[]byte', 'interface{}'}
@@ -26,6 +26,7 @@ def is_primitive(go_type):
     if go_type.startswith('metav1.') or go_type.startswith('corev1.'):
         return True
     return False
+
 
 def find_go_struct(type_name, go_files):
     # Look for a struct definition with the exact type name
@@ -51,6 +52,7 @@ def find_go_struct(type_name, go_files):
                     if len(parts) == 1 and parts[0] == type_name:
                         return struct_body, file_path, content
     return None, None, None
+
 
 def parse_go_struct(type_name, go_files, parsed_types):
     if type_name in parsed_types:
@@ -104,6 +106,7 @@ def parse_go_struct(type_name, go_files, parsed_types):
         fields.append(field_info)
     return {'kind': type_name, 'description': struct_comment, 'fields': fields}
 
+
 def parse_go_file(file_path, go_files, parsed_types=None):
     if parsed_types is None:
         parsed_types = set()
@@ -118,13 +121,30 @@ def parse_go_file(file_path, go_files, parsed_types=None):
     spec_struct_name = kind + 'Spec'
     return parse_go_struct(spec_struct_name, go_files, parsed_types)
 
+
 def parse_crd_file(file_path):
     with open(file_path, 'r') as f:
-        try:
-            crd = yaml.safe_load(f)
-        except yaml.YAMLError as e:
-            print(f"Error parsing YAML file {file_path}: {e}")
-            return None
+        content = f.read()
+
+    # Filter out Helm template syntax before parsing YAML
+    # Remove Helm template blocks like {{- if .Values.manageCRDs }}, {{ .Values.something }}, etc.
+    import re
+    # Remove Helm template conditionals and loops
+    content = re.sub(r'\{\{-?\s*if\s+[^}]+\s*-?\}\}', '', content)
+    content = re.sub(r'\{\{-?\s*else\s*-?\}\}', '', content)
+    content = re.sub(r'\{\{-?\s*end\s*-?\}\}', '', content)
+    content = re.sub(r'\{\{-?\s*range\s+[^}]+\s*-?\}\}', '', content)
+    content = re.sub(r'\{\{-?\s*with\s+[^}]+\s*-?\}\}', '', content)
+    # Remove Helm template variables like {{ .Values.something }}
+    content = re.sub(r'\{\{-?[^}]+-?\}\}', '', content)
+    # Remove lines that are only whitespace after template removal
+    content = '\n'.join(line for line in content.split('\n') if line.strip())
+
+    try:
+        crd = yaml.safe_load(content)
+    except yaml.YAMLError as e:
+        print(f"Error parsing YAML file {file_path}: {e}")
+        return None
     if not crd or crd.get('kind') != 'CustomResourceDefinition':
         return None
 
@@ -174,7 +194,7 @@ def parse_crd_file(file_path):
                 field_schema = properties[field_name]
                 schema = field_schema.get('properties', {})
                 if 'description' in field_schema:
-                    crd_info['description'+field_name] = field_schema['description']
+                    crd_info['description' + field_name] = field_schema['description']
                 crd_info[field_name] = parse_schema_fields(schema)
     except (KeyError, IndexError) as e:
         print(f"Exception details: {e}")
@@ -183,12 +203,13 @@ def parse_crd_file(file_path):
         pass
     return crd_info
 
+
 def render_fields(fields, go_files, depth=0):
     md = ''
     indent = ''
 
     if depth > 0:
-        indent = "&nbsp;" * ((depth - 1) * 4) +"└>" + "&nbsp;" * 2
+        indent = "&nbsp;" * ((depth - 1) * 4) + "└>" + "&nbsp;" * 2
 
     for field in fields:
         if isinstance(field, str):
@@ -202,9 +223,10 @@ def render_fields(fields, go_files, depth=0):
         description = field.get('description', 'No description provided.').replace('\n', ' ')
         md += f"| {indent} **{field.get('name', 'N/A')}** | `{field.get('type', 'N/A')}` | {description} | {validations} |\n"
         if 'inline' in field and len(field['inline']) > 0:
-            md += render_fields(field['inline']['fields'], go_files, depth+1)
+            md += render_fields(field['inline']['fields'], go_files, depth + 1)
 
     return md
+
 
 def generate_markdown(crd_info, output_dir, go_files):
     kind = crd_info['kind']
@@ -223,6 +245,7 @@ def generate_markdown(crd_info, output_dir, go_files):
         f.write(render_fields(crd_info.get('status', []), go_files))
     return f"{kind.lower()}_api.md"
 
+
 def collect_go_type_files():
     go_type_files = []
     for root, _, files in os.walk(search_dir):
@@ -232,6 +255,7 @@ def collect_go_type_files():
             if file.endswith('.go') and not file.startswith('zz_generated') and not file.startswith('doc.go'):
                 go_type_files.append(os.path.join(root, file))
     return go_type_files
+
 
 def main():
     import sys
@@ -297,6 +321,7 @@ def main():
             f.write(f"[View a detailed API Reference for {entry['kind']}]({entry['link']}).\n\n")
             f.write("---\n\n")
     print(f"API documentation generated successfully in the '{api_docs_dir}' directory.")
+
 
 if __name__ == "__main__":
     main()

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,98 @@
+# gen-api-docs Tests
+
+This directory contains comprehensive tests for the `gen-api-docs.py` script.
+
+## Test Files
+
+### `test_crd_import.py`
+Tests for CRD (Custom Resource Definition) import functionality:
+- Valid CRD parsing
+- Invalid YAML handling
+- Missing CRD fields
+- Array properties
+- Validation rules extraction
+- Schema parsing
+
+### `test_helm_template_removal.py`
+Tests for Helm template code removal:
+- Conditional template removal (`{{- if }}`)
+- Mixed content handling
+- Empty line cleanup
+
+### `test_integration.py`
+Integration tests for the complete workflow:
+- CRD priority over `_types.go`
+- Multiple resource processing
+- Ignored folder handling
+- Markdown generation format
+- Complete end-to-end workflows
+
+## Test Data
+
+### `test_data/sample_crd.yaml`
+A sample CRD file with various field types and validations for testing.
+
+### `test_data/sample_types.go`
+A sample `_types.go` file with various struct definitions, validations, and embedded types.
+
+### `test_data/sample_helm_crd.yaml`
+A sample CRD file with Helm templates for testing template removal functionality.
+
+## Running Tests
+
+### Run all tests:
+```bash
+make test
+```
+
+### Run individual tests:
+```bash
+make test-crd-import
+make test-helm-template-removal
+make test-integration
+```
+
+### Run with verbose output:
+```bash
+make test-verbose
+```
+
+## Test Coverage
+
+The tests cover:
+
+1. **CRD Import Validation**:
+   - Valid CRD parsing with all field types
+   - Invalid YAML handling
+   - Missing or malformed CRD structures
+   - Array and object property handling
+   - Validation rule extraction (minimum, maximum, pattern, enum)
+
+3. **Helm Template Removal Validation**:
+   - All Helm template syntax patterns
+   - Conditional blocks (`{{- if }}`, `{{- else }}`, `{{- end }}`)
+   - Mixed template and YAML content
+   - Empty line cleanup after template removal
+
+4. **Integration Testing**:
+   - Complete workflow validation
+   - CRD vs `_types.go` priority handling
+   - Multiple resource processing
+   - Ignored folder functionality
+   - Markdown generation format validation
+
+## Expected Test Results
+
+All tests should pass and validate that:
+- CRD files are properly parsed and their schemas extracted
+- Helm templates are completely removed while preserving valid YAML
+- The integration workflow works correctly end-to-end
+- Generated markdown has the correct format and content
+
+## Troubleshooting
+
+If tests fail:
+1. Check that the `cmd/gen-api-docs.py` file is accessible
+2. Ensure all required Python packages are installed (`yaml`, `unittest`)
+3. Verify that test data files are present in `test_data/`
+4. Check that the test directory structure matches the expected layout 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""
+Test runner for gen-api-docs tests
+"""
+
+import os
+import sys
+import unittest
+import argparse
+
+
+def run_tests(test_pattern="test_*.py"):
+    """Run all tests matching the pattern"""
+    # Add the current directory to the path
+    sys.path.insert(0, os.path.dirname(__file__))
+
+    # Discover and run tests
+    loader = unittest.TestLoader()
+    suite = loader.discover(os.path.dirname(__file__), pattern=test_pattern)
+
+    runner = unittest.TextTestRunner(verbosity=2)
+    result = runner.run(suite)
+
+    return result.wasSuccessful()
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Run gen-api-docs tests')
+    parser.add_argument('--pattern', default='test_*.py',
+                        help='Test file pattern (default: test_*.py)')
+    parser.add_argument('--verbose', '-v', action='store_true',
+                        help='Verbose output')
+
+    args = parser.parse_args()
+
+    print("Running gen-api-docs tests...")
+    print(f"Test pattern: {args.pattern}")
+    print("=" * 50)
+
+    success = run_tests(args.pattern)
+
+    print("=" * 50)
+    if success:
+        print("✅ All tests passed!")
+        sys.exit(0)
+    else:
+        print("❌ Some tests failed!")
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_crd_import.py
+++ b/tests/test_crd_import.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""
+Tests for CRD import functionality in gen-api-docs.py
+"""
+
+import os
+import tempfile
+import unittest
+import yaml
+import importlib.util
+
+# Import the module by executing the file
+spec = importlib.util.spec_from_file_location("gen_api_docs", os.path.join(os.path.dirname(__file__), '..', 'cmd', 'gen-api-docs.py'))
+gen_api_docs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(gen_api_docs)
+
+
+class TestCRDImport(unittest.TestCase):
+    """Test cases for CRD import functionality"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.test_crd_data = {
+            'apiVersion': 'apiextensions.k8s.io/v1',
+            'kind': 'CustomResourceDefinition',
+            'metadata': {
+                'name': 'testresources.example.com'
+            },
+            'spec': {
+                'group': 'example.com',
+                'names': {
+                    'kind': 'TestResource',
+                    'plural': 'testresources',
+                    'singular': 'testresource'
+                },
+                'scope': 'Namespaced',
+                'versions': [{
+                    'name': 'v1alpha1',
+                    'served': True,
+                    'storage': True,
+                    'schema': {
+                        'openAPIV3Schema': {
+                            'type': 'object',
+                            'properties': {
+                                'spec': {
+                                    'type': 'object',
+                                    'description': 'Specification for TestResource',
+                                    'properties': {
+                                        'name': {
+                                            'type': 'string',
+                                            'description': 'The name of the resource',
+                                            'pattern': '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+                                        },
+                                        'replicas': {
+                                            'type': 'integer',
+                                            'description': 'Number of replicas',
+                                            'minimum': 1,
+                                            'maximum': 10
+                                        },
+                                        'config': {
+                                            'type': 'object',
+                                            'description': 'Configuration object',
+                                            'properties': {
+                                                'enabled': {
+                                                    'type': 'boolean',
+                                                    'description': 'Whether the feature is enabled'
+                                                },
+                                                'timeout': {
+                                                    'type': 'integer',
+                                                    'description': 'Timeout in seconds',
+                                                    'minimum': 1
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                'status': {
+                                    'type': 'object',
+                                    'description': 'Status of TestResource',
+                                    'properties': {
+                                        'phase': {
+                                            'type': 'string',
+                                            'description': 'Current phase of the resource',
+                                            'enum': ['Pending', 'Running', 'Completed', 'Failed']
+                                        },
+                                        'readyReplicas': {
+                                            'type': 'integer',
+                                            'description': 'Number of ready replicas'
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }]
+            }
+        }
+
+    def test_parse_crd_file_valid(self):
+        """Test parsing a valid CRD file"""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            yaml.dump(self.test_crd_data, f)
+            temp_file = f.name
+
+        try:
+            result = gen_api_docs.parse_crd_file(temp_file)
+
+            self.assertIsNotNone(result)
+            self.assertEqual(result['kind'], 'TestResource')
+            self.assertEqual(result['description'], 'Description not found in CRD.')
+
+            # Check spec fields
+            spec_fields = result.get('spec', [])
+            self.assertEqual(len(spec_fields), 3)
+
+            # Check name field
+            name_field = next((f for f in spec_fields if f['name'] == 'name'), None)
+            self.assertIsNotNone(name_field)
+            self.assertEqual(name_field['type'], 'string')
+            self.assertEqual(name_field['description'], 'The name of the resource')
+            self.assertIn('Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$', name_field['validations'])
+
+            # Check replicas field
+            replicas_field = next((f for f in spec_fields if f['name'] == 'replicas'), None)
+            self.assertIsNotNone(replicas_field)
+            self.assertEqual(replicas_field['type'], 'integer')
+            self.assertIn('Minimum=1', replicas_field['validations'])
+            self.assertIn('Maximum=10', replicas_field['validations'])
+
+            # Check config field (nested object)
+            config_field = next((f for f in spec_fields if f['name'] == 'config'), None)
+            self.assertIsNotNone(config_field)
+            self.assertEqual(config_field['type'], 'object')
+            self.assertIn('inline', config_field)
+
+            # Check status fields
+            status_fields = result.get('status', [])
+            self.assertEqual(len(status_fields), 2)
+
+            phase_field = next((f for f in status_fields if f['name'] == 'phase'), None)
+            self.assertIsNotNone(phase_field)
+            self.assertEqual(phase_field['type'], 'string')
+
+        finally:
+            os.unlink(temp_file)
+
+    def test_parse_crd_file_invalid_yaml(self):
+        """Test parsing an invalid YAML file"""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write("invalid: yaml: content: [")
+            temp_file = f.name
+
+        try:
+            result = gen_api_docs.parse_crd_file(temp_file)
+            self.assertIsNone(result)
+        finally:
+            os.unlink(temp_file)
+
+    def test_parse_crd_file_not_crd(self):
+        """Test parsing a YAML file that is not a CRD"""
+        non_crd_data = {
+            'apiVersion': 'v1',
+            'kind': 'Pod',
+            'metadata': {'name': 'test-pod'},
+            'spec': {'containers': []}
+        }
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            yaml.dump(non_crd_data, f)
+            temp_file = f.name
+
+        try:
+            result = gen_api_docs.parse_crd_file(temp_file)
+            self.assertIsNone(result)
+        finally:
+            os.unlink(temp_file)
+
+    def test_parse_crd_file_empty_schema(self):
+        """Test parsing a CRD file with empty schema"""
+        empty_schema_crd = {
+            'apiVersion': 'apiextensions.k8s.io/v1',
+            'kind': 'CustomResourceDefinition',
+            'metadata': {'name': 'test.example.com'},
+            'spec': {
+                'group': 'example.com',
+                'names': {'kind': 'Test'},
+                'scope': 'Namespaced',
+                'versions': [{
+                    'name': 'v1alpha1',
+                    'served': True,
+                    'storage': True,
+                    'schema': {
+                        'openAPIV3Schema': {
+                            'type': 'object',
+                            'properties': {}
+                        }
+                    }
+                }]
+            }
+        }
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            yaml.dump(empty_schema_crd, f)
+            temp_file = f.name
+
+        try:
+            result = gen_api_docs.parse_crd_file(temp_file)
+            self.assertIsNotNone(result)
+            self.assertEqual(result['kind'], 'Test')
+            self.assertEqual(len(result.get('spec', [])), 0)
+            self.assertEqual(len(result.get('status', [])), 0)
+        finally:
+            os.unlink(temp_file)
+
+    def test_parse_crd_file_with_array_properties(self):
+        """Test parsing a CRD file with array properties"""
+        array_crd_data = {
+            'apiVersion': 'apiextensions.k8s.io/v1',
+            'kind': 'CustomResourceDefinition',
+            'metadata': {'name': 'test.example.com'},
+            'spec': {
+                'group': 'example.com',
+                'names': {'kind': 'TestArray'},
+                'scope': 'Namespaced',
+                'versions': [{
+                    'name': 'v1alpha1',
+                    'served': True,
+                    'storage': True,
+                    'schema': {
+                        'openAPIV3Schema': {
+                            'type': 'object',
+                            'properties': {
+                                'spec': {
+                                    'type': 'object',
+                                    'properties': {
+                                        'items': {
+                                            'type': 'array',
+                                            'description': 'List of items',
+                                            'items': {
+                                                'type': 'object',
+                                                'properties': {
+                                                    'name': {
+                                                        'type': 'string',
+                                                        'description': 'Item name'
+                                                    },
+                                                    'value': {
+                                                        'type': 'integer',
+                                                        'description': 'Item value'
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }]
+            }
+        }
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            yaml.dump(array_crd_data, f)
+            temp_file = f.name
+
+        try:
+            result = gen_api_docs.parse_crd_file(temp_file)
+            self.assertIsNotNone(result)
+            self.assertEqual(result['kind'], 'TestArray')
+
+            spec_fields = result.get('spec', [])
+            self.assertEqual(len(spec_fields), 1)
+
+            items_field = spec_fields[0]
+            self.assertEqual(items_field['name'], 'items')
+            self.assertEqual(items_field['type'], 'array')
+            self.assertIn('inline', items_field)
+        finally:
+            os.unlink(temp_file)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_data/sample_crd.yaml
+++ b/tests/test_data/sample_crd.yaml
@@ -1,0 +1,86 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: sample.example.com
+spec:
+  group: example.com
+  names:
+    kind: Sample
+    plural: samples
+    singular: sample
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            description: Specification for Sample resource
+            properties:
+              name:
+                type: string
+                description: The name of the sample resource
+                pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+              replicas:
+                type: integer
+                description: Number of replicas to run
+                minimum: 1
+                maximum: 10
+              enabled:
+                type: boolean
+                description: Whether the sample is enabled
+              config:
+                type: object
+                description: Configuration object
+                properties:
+                  timeout:
+                    type: integer
+                    description: Timeout in seconds
+                    minimum: 1
+                  retries:
+                    type: integer
+                    description: Number of retries
+                    minimum: 0
+                    maximum: 5
+              items:
+                type: array
+                description: List of items
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                      description: Item name
+                    value:
+                      type: integer
+                      description: Item value
+          status:
+            type: object
+            description: Status of Sample resource
+            properties:
+              phase:
+                type: string
+                description: Current phase of the sample
+                enum: [Pending, Running, Completed, Failed]
+              readyReplicas:
+                type: integer
+                description: Number of ready replicas
+              conditions:
+                type: array
+                description: List of conditions
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      description: Type of condition
+                    status:
+                      type: string
+                      description: Status of condition
+                    message:
+                      type: string
+                      description: Message describing the condition 

--- a/tests/test_data/sample_helm_crd.yaml
+++ b/tests/test_data/sample_helm_crd.yaml
@@ -1,0 +1,73 @@
+{{- if .Values.enableCRD }}
+apiVersion: apiextensions.k8s.io/v1
+{{- end }}
+kind: CustomResourceDefinition
+metadata:
+  name: helm-sample.example.com
+spec:
+  group: example.com
+  names:
+    kind: HelmSample
+    plural: helmsamples
+    singular: helmsample
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            description: Specification for HelmSample resource
+            properties:
+              name:
+                type: string
+                description: The name of the helm sample resource
+                pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+              replicas:
+                type: integer
+                description: Number of replicas to run
+                minimum: 1
+                maximum: 10
+              enabled:
+                type: boolean
+                description: Whether the helm sample is enabled
+              config:
+                type: object
+                description: Configuration object
+                properties:
+                  timeout:
+                    type: integer
+                    description: Timeout in seconds
+                    minimum: 1
+                  retries:
+                    type: integer
+                    description: Number of retries
+                    minimum: 0
+                    maximum: 5
+              items:
+                type: array
+                description: List of items
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                      description: Item name
+                    value:
+                      type: integer
+                      description: Item value
+          status:
+            type: object
+            description: Status of HelmSample resource
+            properties:
+              phase:
+                type: string
+                description: Current phase of the helm sample
+                enum: [Pending, Running, Completed, Failed]
+              readyReplicas:
+                type: integer
+                description: Number of ready replicas 

--- a/tests/test_data/sample_types.go
+++ b/tests/test_data/sample_types.go
@@ -1,0 +1,123 @@
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// SampleSpec defines the desired state of Sample
+type SampleSpec struct {
+	// Name is the name of the sample resource
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+	Name string `json:"name"`
+
+	// Replicas is the number of replicas to run
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=10
+	Replicas int32 `json:"replicas"`
+
+	// Enabled determines if the sample is enabled
+	Enabled bool `json:"enabled"`
+
+	// Config contains configuration options
+	Config SampleConfig `json:"config"`
+
+	// Items is a list of items
+	Items []SampleItem `json:"items"`
+
+	// Embedded metav1.TypeMeta
+	metav1.TypeMeta `json:",inline"`
+
+	// Embedded metav1.ObjectMeta
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	// EmbeddedStruct is an embedded struct
+	EmbeddedStruct `json:"embedded"`
+}
+
+// SampleConfig defines configuration options
+type SampleConfig struct {
+	// Timeout is the timeout in seconds
+	// +kubebuilder:validation:Minimum=1
+	Timeout int32 `json:"timeout"`
+
+	// Retries is the number of retries
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=5
+	Retries int32 `json:"retries"`
+
+	// Settings contains additional settings
+	Settings map[string]string `json:"settings"`
+}
+
+// SampleItem represents an item in the list
+type SampleItem struct {
+	// Name is the name of the item
+	Name string `json:"name"`
+
+	// Value is the value of the item
+	Value int32 `json:"value"`
+
+	// Description with special characters: < > & " '
+	Description string `json:"description"`
+}
+
+// EmbeddedStruct is an embedded struct
+type EmbeddedStruct struct {
+	// EmbeddedField is a field in the embedded struct
+	EmbeddedField string `json:"embeddedField"`
+
+	// Another embedded field
+	AnotherField int32 `json:"anotherField"`
+}
+
+// SampleStatus defines the observed state of Sample
+type SampleStatus struct {
+	// Phase represents the current phase
+	// +kubebuilder:validation:Enum=Pending;Running;Completed;Failed
+	Phase string `json:"phase"`
+
+	// ReadyReplicas is the number of ready replicas
+	ReadyReplicas int32 `json:"readyReplicas"`
+
+	// Conditions represents the latest available observations
+	Conditions []SampleCondition `json:"conditions"`
+
+	// Self-referencing field for testing recursion
+	Parent *SampleStatus `json:"parent"`
+}
+
+// SampleCondition represents a condition
+type SampleCondition struct {
+	// Type is the type of condition
+	Type string `json:"type"`
+
+	// Status is the status of the condition
+	Status string `json:"status"`
+
+	// Message is the message describing the condition
+	Message string `json:"message"`
+
+	// LastTransitionTime is the last time the condition transitioned
+	LastTransitionTime metav1.Time `json:"lastTransitionTime"`
+}
+
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+
+// Sample is the Schema for the samples API
+type Sample struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   SampleSpec   `json:"spec,omitempty"`
+	Status SampleStatus `json:"status,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+
+// SampleList contains a list of Sample
+type SampleList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []Sample `json:"items"`
+}

--- a/tests/test_helm_template_removal.py
+++ b/tests/test_helm_template_removal.py
@@ -1,0 +1,547 @@
+#!/usr/bin/env python3
+"""
+Tests for Helm template code removal functionality in gen-api-docs.py
+"""
+
+import importlib.util
+import os
+import tempfile
+import unittest
+
+# Import the module by executing the file
+spec = importlib.util.spec_from_file_location("gen_api_docs", os.path.join(os.path.dirname(__file__), '..', 'cmd', 'gen-api-docs.py'))
+gen_api_docs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(gen_api_docs)
+
+
+class TestHelmTemplateRemoval(unittest.TestCase):
+    """Test cases for Helm template code removal functionality"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.base_crd_data = {
+            'apiVersion': 'apiextensions.k8s.io/v1',
+            'kind': 'CustomResourceDefinition',
+            'metadata': {
+                'name': 'testresources.example.com'
+            },
+            'spec': {
+                'group': 'example.com',
+                'names': {
+                    'kind': 'TestResource',
+                    'plural': 'testresources',
+                    'singular': 'testresource'
+                },
+                'scope': 'Namespaced',
+                'versions': [{
+                    'name': 'v1alpha1',
+                    'served': True,
+                    'storage': True,
+                    'schema': {
+                        'openAPIV3Schema': {
+                            'type': 'object',
+                            'properties': {
+                                'spec': {
+                                    'type': 'object',
+                                    'properties': {
+                                        'name': {
+                                            'type': 'string',
+                                            'description': 'The name of the resource'
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }]
+            }
+        }
+
+    def test_helm_template_conditional_removal(self):
+        """Test removal of Helm template conditionals"""
+        helm_template_content = '''
+{{- if .Values.manageCRDs }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: testresources.example.com
+spec:
+  group: example.com
+  names:
+    kind: TestResource
+    plural: testresources
+    singular: testresource
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              name:
+                type: string
+                description: The name of the resource
+{{- end }}
+'''
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write(helm_template_content)
+            temp_file = f.name
+
+        try:
+            result = gen_api_docs.parse_crd_file(temp_file)
+
+            # Should parse successfully after template removal
+            self.assertIsNotNone(result)
+            self.assertEqual(result['kind'], 'TestResource')
+
+        finally:
+            os.unlink(temp_file)
+
+    def test_helm_template_variable_substitution_removal(self):
+        """Test removal of Helm template variable substitutions"""
+        helm_template_content = '''
+{{- if .Values.enableCRD }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: testresources.example.com
+  namespace: default
+spec:
+  group: example.com
+  names:
+    kind: TestResource
+    plural: testresources
+    singular: testresource
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              name:
+                type: string
+                description: The name of the resource
+{{- end }}
+'''
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write(helm_template_content)
+            temp_file = f.name
+
+        try:
+            result = gen_api_docs.parse_crd_file(temp_file)
+
+            # Should parse successfully after template removal
+            self.assertIsNotNone(result)
+            self.assertEqual(result['kind'], 'TestResource')
+
+        finally:
+            os.unlink(temp_file)
+
+    def test_helm_template_range_removal(self):
+        """Test removal of Helm template range loops"""
+        helm_template_content = '''
+{{- if .Values.enableVersions }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: testresources.example.com
+spec:
+  group: example.com
+  names:
+    kind: TestResource
+    plural: testresources
+    singular: testresource
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              name:
+                type: string
+                description: The name of the resource
+{{- end }}
+'''
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write(helm_template_content)
+            temp_file = f.name
+
+        try:
+            result = gen_api_docs.parse_crd_file(temp_file)
+
+            # Should parse successfully after template removal
+            self.assertIsNotNone(result)
+            self.assertEqual(result['kind'], 'TestResource')
+
+        finally:
+            os.unlink(temp_file)
+
+    def test_helm_template_with_removal(self):
+        """Test removal of Helm template with blocks"""
+        helm_template_content = '''
+{{- if .Values.enableSpecProperties }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: testresources.example.com
+spec:
+  group: example.com
+  names:
+    kind: TestResource
+    plural: testresources
+    singular: testresource
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              name:
+                type: string
+                description: The name of the resource
+{{- end }}
+'''
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write(helm_template_content)
+            temp_file = f.name
+
+        try:
+            result = gen_api_docs.parse_crd_file(temp_file)
+
+            # Should parse successfully after template removal
+            self.assertIsNotNone(result)
+            self.assertEqual(result['kind'], 'TestResource')
+
+        finally:
+            os.unlink(temp_file)
+
+    def test_helm_template_complex_nested_removal(self):
+        """Test removal of complex nested Helm templates"""
+        helm_template_content = '''
+{{- if .Values.enableCRD }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: testresources.example.com
+spec:
+  group: example.com
+  names:
+    kind: TestResource
+    plural: testresources
+    singular: testresource
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              name:
+                type: string
+                description: The name of the resource
+{{- end }}
+'''
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write(helm_template_content)
+            temp_file = f.name
+
+        try:
+            result = gen_api_docs.parse_crd_file(temp_file)
+
+            # Should parse successfully after template removal
+            self.assertIsNotNone(result)
+            self.assertEqual(result['kind'], 'TestResource')
+
+        finally:
+            os.unlink(temp_file)
+
+    def test_helm_template_else_removal(self):
+        """Test removal of Helm template else blocks"""
+        helm_template_content = '''
+{{- if .Values.useCustomName }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: testresources.example.com
+spec:
+  group: example.com
+  names:
+    kind: TestResource
+    plural: testresources
+    singular: testresource
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              name:
+                type: string
+                description: Default name field
+{{- end }}
+'''
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write(helm_template_content)
+            temp_file = f.name
+
+        try:
+            result = gen_api_docs.parse_crd_file(temp_file)
+
+            # Should parse successfully after template removal
+            self.assertIsNotNone(result)
+            self.assertEqual(result['kind'], 'TestResource')
+
+        finally:
+            os.unlink(temp_file)
+
+    def test_helm_template_mixed_content_removal(self):
+        """Test removal of Helm templates mixed with regular YAML content"""
+        helm_template_content = '''
+{{- if .Values.enableCRD }}
+# This is a comment
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: testresources.example.com
+  # Another comment
+spec:
+  group: example.com
+  names:
+    kind: TestResource
+    plural: testresources
+    singular: testresource
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              name:
+                type: string
+                description: The name of the resource
+                # Inline comment
+                pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+{{- end }}
+'''
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write(helm_template_content)
+            temp_file = f.name
+
+        try:
+            result = gen_api_docs.parse_crd_file(temp_file)
+
+            # Should parse successfully after template removal
+            self.assertIsNotNone(result)
+            self.assertEqual(result['kind'], 'TestResource')
+
+            # Check that the pattern validation is preserved
+            spec_fields = result.get('spec', [])
+            name_field = next((f for f in spec_fields if f['name'] == 'name'), None)
+            self.assertIsNotNone(name_field)
+            self.assertIn('Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$', name_field['validations'])
+
+        finally:
+            os.unlink(temp_file)
+
+    def test_helm_template_empty_lines_removal(self):
+        """Test that empty lines are properly handled after template removal"""
+        helm_template_content = '''
+{{- if .Values.enableCRD }}
+
+apiVersion: apiextensions.k8s.io/v1
+
+kind: CustomResourceDefinition
+
+metadata:
+  name: testresources.example.com
+
+spec:
+  group: example.com
+
+  names:
+    kind: TestResource
+
+    plural: testresources
+
+    singular: testresource
+
+  scope: Namespaced
+
+  versions:
+  - name: v1alpha1
+
+    served: true
+
+    storage: true
+
+    schema:
+      openAPIV3Schema:
+        type: object
+
+        properties:
+          spec:
+            type: object
+
+            properties:
+              name:
+                type: string
+
+                description: The name of the resource
+
+{{- end }}
+'''
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write(helm_template_content)
+            temp_file = f.name
+
+        try:
+            result = gen_api_docs.parse_crd_file(temp_file)
+
+            # Should parse successfully after template removal
+            self.assertIsNotNone(result)
+            self.assertEqual(result['kind'], 'TestResource')
+
+        finally:
+            os.unlink(temp_file)
+
+    def test_helm_template_invalid_yaml_after_removal(self):
+        """Test handling of invalid YAML after template removal"""
+        helm_template_content = '''
+{{- if .Values.enableCRD }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: testresources.example.com
+spec:
+  group: example.com
+  names:
+    kind: TestResource
+    plural: testresources
+    singular: testresource
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              name:
+                type: string
+                description: The name of the resource
+{{- end }}
+  invalid: yaml: structure: [
+'''
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write(helm_template_content)
+            temp_file = f.name
+
+        try:
+            result = gen_api_docs.parse_crd_file(temp_file)
+
+            # Should return None due to invalid YAML
+            self.assertIsNone(result)
+
+        finally:
+            os.unlink(temp_file)
+
+    def test_helm_template_no_templates(self):
+        """Test parsing YAML file without any Helm templates"""
+        regular_yaml_content = '''
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: testresources.example.com
+spec:
+  group: example.com
+  names:
+    kind: TestResource
+    plural: testresources
+    singular: testresource
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              name:
+                type: string
+                description: The name of the resource
+'''
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write(regular_yaml_content)
+            temp_file = f.name
+
+        try:
+            result = gen_api_docs.parse_crd_file(temp_file)
+
+            # Should parse successfully
+            self.assertIsNotNone(result)
+            self.assertEqual(result['kind'], 'TestResource')
+
+        finally:
+            os.unlink(temp_file)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python3
+"""
+Integration tests for the complete gen-api-docs workflow
+"""
+
+import os
+import tempfile
+import unittest
+import shutil
+import importlib.util
+from unittest.mock import patch
+
+# Import the module by executing the file
+spec = importlib.util.spec_from_file_location("gen_api_docs", os.path.join(os.path.dirname(__file__), '..', 'cmd', 'gen-api-docs.py'))
+gen_api_docs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(gen_api_docs)
+
+
+class TestIntegration(unittest.TestCase):
+    """Integration tests for the complete workflow"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.test_dir = tempfile.mkdtemp()
+        self.original_search_dir = gen_api_docs.search_dir
+        gen_api_docs.search_dir = self.test_dir
+
+    def tearDown(self):
+        """Clean up test fixtures"""
+        gen_api_docs.search_dir = self.original_search_dir
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def create_test_crd_file(self, filename, content):
+        """Helper to create a test CRD file"""
+        filepath = os.path.join(self.test_dir, filename)
+        with open(filepath, 'w') as f:
+            f.write(content)
+        return filepath
+
+    def create_test_types_file(self, filename, content):
+        """Helper to create a test _types.go file"""
+        filepath = os.path.join(self.test_dir, filename)
+        with open(filepath, 'w') as f:
+            f.write(content)
+        return filepath
+
+    def test_crd_priority_over_types(self):
+        """Test that CRD files take priority over _types.go files"""
+        # Create a _types.go file
+        types_content = '''
+package v1alpha1
+
+// TestResourceSpec defines the desired state of TestResource
+type TestResourceSpec struct {
+    // Name from types.go
+    Name string `json:"name"`
+
+    // Type from types.go
+    Type string `json:"type"`
+}
+'''
+        self.create_test_types_file('testresource_types.go', types_content)
+
+        # Create a CRD file with different fields
+        crd_content = '''
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: testresources.example.com
+spec:
+  group: example.com
+  names:
+    kind: TestResource
+    plural: testresources
+    singular: testresource
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            description: Specification for TestResource
+            properties:
+              name:
+                type: string
+                description: The name from CRD
+              replicas:
+                type: integer
+                description: Number of replicas from CRD
+                minimum: 1
+                maximum: 10
+          status:
+            type: object
+            description: Status of TestResource
+            properties:
+              phase:
+                type: string
+                description: Current phase
+                enum: [Pending, Running, Completed, Failed]
+'''
+        self.create_test_crd_file('testresource-crd.yaml', crd_content)
+
+        # Run the main function
+        with patch('builtins.print'):  # Suppress print output
+            gen_api_docs.main()
+
+        # Check that the CRD was used (not the types.go)
+        api_docs_dir = os.path.join(self.test_dir, 'api-docs')
+        self.assertTrue(os.path.exists(api_docs_dir))
+
+        # Check that the markdown file was generated
+        md_file = os.path.join(api_docs_dir, 'testresource_api.md')
+        self.assertTrue(os.path.exists(md_file))
+
+        # Read the generated markdown and verify CRD content was used
+        with open(md_file, 'r') as f:
+            content = f.read()
+
+        # Should contain CRD fields, not types.go fields
+        self.assertIn('replicas', content)
+        self.assertIn('Number of replicas from CRD', content)
+        self.assertIn('phase', content)
+        self.assertNotIn('Type from types.go', content)
+
+    def test_types_go_when_no_crd(self):
+        """Test that _types.go files are used when no CRD is present"""
+        # Create only a _types.go file
+        types_content = '''
+package v1alpha1
+
+// TestResourceSpec defines the desired state of TestResource
+type TestResourceSpec struct {
+    // Name is the name of the resource
+    // +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+    Name string `json:"name"`
+
+    // Replicas is the number of replicas
+    // +kubebuilder:validation:Minimum=1
+    // +kubebuilder:validation:Maximum=10
+    Replicas int32 `json:"replicas"`
+
+    // Config contains configuration
+    Config TestConfig `json:"config"`
+}
+
+// TestConfig defines configuration options
+type TestConfig struct {
+    // Timeout is the timeout in seconds
+    Timeout int32 `json:"timeout"`
+
+    // Retries is the number of retries
+    Retries int32 `json:"retries"`
+}
+'''
+        self.create_test_types_file('testresource_types.go', types_content)
+
+        # Run the main function
+        with patch('builtins.print'):  # Suppress print output
+            gen_api_docs.main()
+
+        # Check that the markdown file was generated
+        api_docs_dir = os.path.join(self.test_dir, 'api-docs')
+        md_file = os.path.join(api_docs_dir, 'testresource_api.md')
+        self.assertTrue(os.path.exists(md_file))
+
+        # Read the generated markdown and verify types.go content was used
+        with open(md_file, 'r') as f:
+            content = f.read()
+
+        # Should contain types.go fields
+        self.assertIn('Name is the name of the resource', content)
+        self.assertIn('Replicas is the number of replicas', content)
+        self.assertIn('Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$', content)
+        self.assertIn('Minimum=1', content)
+        self.assertIn('Maximum=10', content)
+
+    def test_helm_template_removal_integration(self):
+        """Test Helm template removal in the complete workflow"""
+        # Create a CRD file with Helm templates
+        helm_crd_content = '''
+{{- if .Values.manageCRDs }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: {{ .Values.crdName | default "testresources.example.com" }}
+spec:
+  group: {{ .Values.group | default "example.com" }}
+  names:
+    kind: {{ .Values.kind | default "TestResource" }}
+    plural: {{ .Values.plural | default "testresources" }}
+    singular: {{ .Values.singular | default "testresource" }}
+  scope: {{ .Values.scope | default "Namespaced" }}
+  versions:
+  - name: {{ .Values.version | default "v1alpha1" }}
+    served: {{ .Values.served | default true }}
+    storage: {{ .Values.storage | default true }}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            description: Specification for TestResource
+            properties:
+              name:
+                type: string
+                description: The name of the resource
+                pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+              replicas:
+                type: integer
+                description: Number of replicas
+                minimum: 1
+                maximum: 10
+{{- end }}
+'''
+        self.create_test_crd_file('testresource-crd.yaml', helm_crd_content)
+
+        # Run the main function
+        with patch('builtins.print'):  # Suppress print output
+            gen_api_docs.main()
+
+        # Check that the markdown file was generated
+        api_docs_dir = os.path.join(self.test_dir, 'api-docs')
+        md_file = os.path.join(api_docs_dir, 'testresource_api.md')
+        self.assertTrue(os.path.exists(md_file))
+
+        # Read the generated markdown and verify content
+        with open(md_file, 'r') as f:
+            content = f.read()
+
+        # Should contain the processed content
+        self.assertIn('TestResource API', content)
+        self.assertIn('The name of the resource', content)
+        self.assertIn('Number of replicas', content)
+        self.assertIn('Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$', content)
+        self.assertIn('Minimum=1', content)
+        self.assertIn('Maximum=10', content)
+
+    def test_multiple_resources(self):
+        """Test processing multiple resources"""
+        # Create multiple CRD files
+        crd1_content = '''
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: resource1.example.com
+spec:
+  group: example.com
+  names:
+    kind: Resource1
+    plural: resource1s
+    singular: resource1
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              name:
+                type: string
+                description: The name of resource1
+'''
+        self.create_test_crd_file('resource1-crd.yaml', crd1_content)
+
+        crd2_content = '''
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: resource2.example.com
+spec:
+  group: example.com
+  names:
+    kind: Resource2
+    plural: resource2s
+    singular: resource2
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              name:
+                type: string
+                description: The name of resource2
+'''
+        self.create_test_crd_file('resource2-crd.yaml', crd2_content)
+
+        # Create a _types.go file for a third resource
+        types_content = '''
+package v1alpha1
+
+// Resource3Spec defines the desired state of Resource3
+type Resource3Spec struct {
+    // Name is the name of resource3
+    Name string `json:"name"`
+}
+'''
+        self.create_test_types_file('resource3_types.go', types_content)
+
+        # Run the main function
+        with patch('builtins.print'):  # Suppress print output
+            gen_api_docs.main()
+
+        # Check that all markdown files were generated
+        api_docs_dir = os.path.join(self.test_dir, 'api-docs')
+        self.assertTrue(os.path.exists(os.path.join(api_docs_dir, 'resource1_api.md')))
+        self.assertTrue(os.path.exists(os.path.join(api_docs_dir, 'resource2_api.md')))
+        self.assertTrue(os.path.exists(os.path.join(api_docs_dir, 'resource3_api.md')))
+
+        # Check that README was generated
+        readme_file = os.path.join(api_docs_dir, 'README.md')
+        self.assertTrue(os.path.exists(readme_file))
+
+        # Read the README and verify all resources are listed
+        with open(readme_file, 'r') as f:
+            content = f.read()
+
+        self.assertIn('Resource1', content)
+        self.assertIn('Resource2', content)
+        self.assertIn('Resource3', content)
+
+    def test_ignored_folders(self):
+        """Test that ignored folders are properly skipped"""
+        # Create ignored folders
+        ignored_dirs = ['vendor', '.github', '.git', 'hack']
+        for ignored_dir in ignored_dirs:
+            os.makedirs(os.path.join(self.test_dir, ignored_dir), exist_ok=True)
+
+            # Create a CRD file in each ignored directory
+            crd_content = '''
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ignored.example.com
+spec:
+  group: example.com
+  names:
+    kind: Ignored
+    plural: ignoreds
+    singular: ignored
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              name:
+                type: string
+                description: This should be ignored
+'''
+            self.create_test_crd_file(os.path.join(ignored_dir, 'ignored-crd.yaml'), crd_content)
+
+        # Create a valid CRD file in the main directory
+        valid_crd_content = '''
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: valid.example.com
+spec:
+  group: example.com
+  names:
+    kind: Valid
+    plural: valids
+    singular: valid
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              name:
+                type: string
+                description: This should be processed
+'''
+        self.create_test_crd_file('valid-crd.yaml', valid_crd_content)
+
+        # Run the main function
+        with patch('builtins.print'):  # Suppress print output
+            gen_api_docs.main()
+
+        # Check that only the valid CRD was processed
+        api_docs_dir = os.path.join(self.test_dir, 'api-docs')
+        self.assertTrue(os.path.exists(os.path.join(api_docs_dir, 'valid_api.md')))
+        self.assertFalse(os.path.exists(os.path.join(api_docs_dir, 'ignored_api.md')))
+
+    def test_markdown_generation_format(self):
+        """Test that generated markdown has the correct format"""
+        # Create a CRD file
+        crd_content = '''
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: test.example.com
+spec:
+  group: example.com
+  names:
+    kind: Test
+    plural: tests
+    singular: test
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            description: Specification for Test
+            properties:
+              name:
+                type: string
+                description: The name of the resource
+                pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+              replicas:
+                type: integer
+                description: Number of replicas
+                minimum: 1
+                maximum: 10
+          status:
+            type: object
+            description: Status of Test
+            properties:
+              phase:
+                type: string
+                description: Current phase
+                enum: [Pending, Running, Completed, Failed]
+'''
+        self.create_test_crd_file('test-crd.yaml', crd_content)
+
+        # Run the main function
+        with patch('builtins.print'):  # Suppress print output
+            gen_api_docs.main()
+
+        # Check the generated markdown
+        api_docs_dir = os.path.join(self.test_dir, 'api-docs')
+        md_file = os.path.join(api_docs_dir, 'test_api.md')
+
+        with open(md_file, 'r') as f:
+            content = f.read()
+
+        # Check markdown structure
+        self.assertIn('# Test API', content)
+        self.assertIn('## Spec Fields', content)
+        self.assertIn('## Status Fields', content)
+        self.assertIn('| Field | Type | Description | Validations |', content)
+        self.assertIn('|:---|---|---|---|', content)
+
+        # Check that fields are properly formatted
+        self.assertIn('**name**', content)
+        self.assertIn('`string`', content)
+        self.assertIn('The name of the resource', content)
+        self.assertIn('`Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`', content)
+
+        self.assertIn('**replicas**', content)
+        self.assertIn('`integer`', content)
+        self.assertIn('Number of replicas', content)
+        self.assertIn('`Minimum=1`', content)
+        self.assertIn('`Maximum=10`', content)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_types_go_import.py
+++ b/tests/test_types_go_import.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+"""
+Tests for _types.go import functionality in gen-api-docs.py
+"""
+
+import os
+import tempfile
+import unittest
+import importlib.util
+from unittest.mock import patch
+
+# Import the module by executing the file
+spec = importlib.util.spec_from_file_location("gen_api_docs", os.path.join(os.path.dirname(__file__), '..', 'cmd', 'gen-api-docs.py'))
+gen_api_docs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(gen_api_docs)
+
+
+class TestTypesGoImport(unittest.TestCase):
+    """Test cases for _types.go import functionality"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.sample_types_go = '''
+// TestResourceSpec defines the desired state of TestResource
+type TestResourceSpec struct {
+    // Name is the name of the resource
+    // +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+    Name string `json:"name"`
+
+    // Replicas is the number of replicas to run
+    // +kubebuilder:validation:Minimum=1
+    // +kubebuilder:validation:Maximum=10
+    Replicas int32 `json:"replicas"`
+
+    // Config contains configuration options
+    Config TestConfig `json:"config"`
+
+    // Enabled determines if the resource is enabled
+    Enabled bool `json:"enabled"`
+
+    // EmbeddedStruct is an embedded struct
+    EmbeddedStruct `json:"embedded"`
+}
+
+// TestConfig defines configuration options
+type TestConfig struct {
+    // Timeout is the timeout in seconds
+    // +kubebuilder:validation:Minimum=1
+    Timeout int32 `json:"timeout"`
+
+    // Retries is the number of retries
+    Retries int32 `json:"retries"`
+}
+
+// EmbeddedStruct is an embedded struct
+type EmbeddedStruct struct {
+    // EmbeddedField is a field in the embedded struct
+    EmbeddedField string `json:"embeddedField"`
+}
+
+// TestResourceStatus defines the observed state of TestResource
+type TestResourceStatus struct {
+    // Phase represents the current phase
+    // +kubebuilder:validation:Enum=Pending;Running;Completed;Failed
+    Phase string `json:"phase"`
+
+    // ReadyReplicas is the number of ready replicas
+    ReadyReplicas int32 `json:"readyReplicas"`
+
+    // Conditions represents the latest available observations
+    Conditions []TestCondition `json:"conditions"`
+}
+
+// TestCondition represents a condition
+type TestCondition struct {
+    // Type is the type of condition
+    Type string `json:"type"`
+
+    // Status is the status of the condition
+    Status string `json:"status"`
+
+    // Message is the message describing the condition
+    Message string `json:"message"`
+}
+'''
+
+    def test_parse_go_file_valid(self):
+        """Test parsing a valid _types.go file"""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='_types.go', delete=False) as f:
+            f.write(self.sample_types_go)
+            temp_file = f.name
+
+        try:
+            # Mock the collect_go_type_files function to return our test file
+            with patch.object(gen_api_docs, 'collect_go_type_files', return_value=[temp_file]):
+                result = gen_api_docs.parse_go_file(temp_file, [temp_file])
+
+                self.assertIsNotNone(result)
+                self.assertEqual(result['kind'], 'TestResource')
+                self.assertEqual(result['description'], 'TestResourceSpec defines the desired state of TestResource')
+
+                # Check fields
+                fields = result.get('fields', [])
+                self.assertEqual(len(fields), 5)
+
+                # Check name field
+                name_field = next((f for f in fields if f['name'] == 'name'), None)
+                self.assertIsNotNone(name_field)
+                self.assertEqual(name_field['type'], 'string')
+                self.assertEqual(name_field['description'], 'Name is the name of the resource')
+                self.assertIn('Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$', name_field['validations'])
+
+                # Check replicas field
+                replicas_field = next((f for f in fields if f['name'] == 'replicas'), None)
+                self.assertIsNotNone(replicas_field)
+                self.assertEqual(replicas_field['type'], 'int32')
+                self.assertIn('Minimum=1', replicas_field['validations'])
+                self.assertIn('Maximum=10', replicas_field['validations'])
+
+                # Check config field (nested struct)
+                config_field = next((f for f in fields if f['name'] == 'config'), None)
+                self.assertIsNotNone(config_field)
+                self.assertEqual(config_field['type'], 'TestConfig')
+                self.assertIn('inline', config_field)
+
+                # Check embedded struct fields are inlined
+                embedded_field = next((f for f in fields if f['name'] == 'embeddedField'), None)
+                self.assertIsNotNone(embedded_field)
+                self.assertEqual(embedded_field['type'], 'string')
+
+        finally:
+            os.unlink(temp_file)
+
+    def test_parse_go_file_no_struct(self):
+        """Test parsing a Go file without struct definitions"""
+        no_struct_content = '''
+package v1alpha1
+
+import (
+    "metav1"
+)
+
+// Some other type definitions
+type SomeType string
+
+const (
+    TypeA SomeType = "A"
+    TypeB SomeType = "B"
+)
+'''
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='_types.go', delete=False) as f:
+            f.write(no_struct_content)
+            temp_file = f.name
+
+        try:
+            with patch.object(gen_api_docs, 'collect_go_type_files', return_value=[temp_file]):
+                result = gen_api_docs.parse_go_file(temp_file, [temp_file])
+                self.assertIsNone(result)
+        finally:
+            os.unlink(temp_file)
+
+    def test_parse_go_struct_with_comments(self):
+        """Test parsing Go struct with various comment styles"""
+        struct_with_comments = '''
+// TestResourceSpec defines the desired state of TestResource
+// This is a multi-line comment
+type TestResourceSpec struct {
+    // Name is the name of the resource
+    // This is also a multi-line comment
+    // +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+    Name string `json:"name"`
+
+    // Description with special characters: < > & " '
+    Description string `json:"description"`
+
+    // Field with no comment
+    NoComment string `json:"noComment"`
+}
+'''
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='_types.go', delete=False) as f:
+            f.write(struct_with_comments)
+            temp_file = f.name
+
+        try:
+            with patch.object(gen_api_docs, 'collect_go_type_files', return_value=[temp_file]):
+                result = gen_api_docs.parse_go_file(temp_file, [temp_file])
+
+                self.assertIsNotNone(result)
+                fields = result.get('fields', [])
+
+                # Check name field with validation
+                name_field = next((f for f in fields if f['name'] == 'name'), None)
+                self.assertIsNotNone(name_field)
+                self.assertEqual(name_field['description'], 'Name is the name of the resource')
+                self.assertIn('Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$', name_field['validations'])
+
+                # Check description field with special characters
+                desc_field = next((f for f in fields if f['name'] == 'description'), None)
+                self.assertIsNotNone(desc_field)
+                self.assertEqual(desc_field['description'], 'Description with special characters: < > & " \'')
+
+                # Check field with no comment
+                no_comment_field = next((f for f in fields if f['name'] == 'noComment'), None)
+                self.assertIsNotNone(no_comment_field)
+                self.assertEqual(no_comment_field['description'], 'No description provided.')
+
+        finally:
+            os.unlink(temp_file)
+
+    def test_parse_go_struct_with_json_tags(self):
+        """Test parsing Go struct with various JSON tag formats"""
+        struct_with_json_tags = '''
+type TestResourceSpec struct {
+    // Field with simple JSON tag
+    Name string `json:"name"`
+
+    // Field with JSON tag and omitempty
+    Optional string `json:"optional,omitempty"`
+
+    // Field with JSON tag and other options
+    Complex string `json:"complex,omitempty,string"`
+
+    // Field with no JSON tag
+    NoTag string
+
+    // Field with empty JSON tag
+    EmptyTag string `json:""`
+}
+'''
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='_types.go', delete=False) as f:
+            f.write(struct_with_json_tags)
+            temp_file = f.name
+
+        try:
+            with patch.object(gen_api_docs, 'collect_go_type_files', return_value=[temp_file]):
+                result = gen_api_docs.parse_go_file(temp_file, [temp_file])
+
+                self.assertIsNotNone(result)
+                fields = result.get('fields', [])
+
+                # Check field with simple JSON tag
+                name_field = next((f for f in fields if f['name'] == 'name'), None)
+                self.assertIsNotNone(name_field)
+
+                # Check field with omitempty
+                optional_field = next((f for f in fields if f['name'] == 'optional'), None)
+                self.assertIsNotNone(optional_field)
+
+                # Check field with complex JSON tag
+                complex_field = next((f for f in fields if f['name'] == 'complex'), None)
+                self.assertIsNotNone(complex_field)
+
+                # Check field with no JSON tag (should use field name)
+                no_tag_field = next((f for f in fields if f['name'] == 'NoTag'), None)
+                self.assertIsNotNone(no_tag_field)
+
+                # Check field with empty JSON tag (should use field name)
+                empty_tag_field = next((f for f in fields if f['name'] == 'EmptyTag'), None)
+                self.assertIsNotNone(empty_tag_field)
+
+        finally:
+            os.unlink(temp_file)
+
+    def test_parse_go_struct_with_embedded_types(self):
+        """Test parsing Go struct with embedded types"""
+        struct_with_embedded = '''
+type TestResourceSpec struct {
+    // Embedded metav1.TypeMeta
+    metav1.TypeMeta `json:",inline"`
+
+    // Embedded metav1.ObjectMeta
+    metav1.ObjectMeta `json:"metadata,omitempty"`
+
+    // Custom embedded struct
+    EmbeddedStruct `json:",inline"`
+
+    // Regular field
+    Name string `json:"name"`
+}
+
+type EmbeddedStruct struct {
+    // Field in embedded struct
+    EmbeddedField string `json:"embeddedField"`
+}
+'''
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='_types.go', delete=False) as f:
+            f.write(struct_with_embedded)
+            temp_file = f.name
+
+        try:
+            with patch.object(gen_api_docs, 'collect_go_type_files', return_value=[temp_file]):
+                result = gen_api_docs.parse_go_file(temp_file, [temp_file])
+
+                self.assertIsNotNone(result)
+                fields = result.get('fields', [])
+
+                # Should have the embedded field inlined
+                embedded_field = next((f for f in fields if f['name'] == 'embeddedField'), None)
+                self.assertIsNotNone(embedded_field)
+
+                # Should have the regular field
+                name_field = next((f for f in fields if f['name'] == 'name'), None)
+                self.assertIsNotNone(name_field)
+
+        finally:
+            os.unlink(temp_file)
+
+    def test_parse_go_struct_recursive_reference(self):
+        """Test parsing Go struct with recursive references"""
+        recursive_struct = '''
+type TestResourceSpec struct {
+    // Self-referencing field
+    Parent *TestResourceSpec `json:"parent"`
+
+    // Field with nested struct that references parent
+    Config TestConfig `json:"config"`
+}
+
+type TestConfig struct {
+    // Reference back to parent
+    Resource *TestResourceSpec `json:"resource"`
+}
+'''
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='_types.go', delete=False) as f:
+            f.write(recursive_struct)
+            temp_file = f.name
+
+        try:
+            with patch.object(gen_api_docs, 'collect_go_type_files', return_value=[temp_file]):
+                result = gen_api_docs.parse_go_file(temp_file, [temp_file])
+
+                self.assertIsNotNone(result)
+                fields = result.get('fields', [])
+
+                # Check that recursive reference is handled
+                parent_field = next((f for f in fields if f['name'] == 'parent'), None)
+                self.assertIsNotNone(parent_field)
+                self.assertEqual(parent_field['type'], '*TestResourceSpec')
+
+        finally:
+            os.unlink(temp_file)
+
+    def test_is_primitive(self):
+        """Test the is_primitive function"""
+        # Test basic primitives
+        self.assertTrue(gen_api_docs.is_primitive('string'))
+        self.assertTrue(gen_api_docs.is_primitive('int'))
+        self.assertTrue(gen_api_docs.is_primitive('bool'))
+        self.assertTrue(gen_api_docs.is_primitive('float64'))
+
+        # Test slices of primitives
+        self.assertTrue(gen_api_docs.is_primitive('[]string'))
+        self.assertTrue(gen_api_docs.is_primitive('[]int'))
+
+        # Test maps
+        self.assertTrue(gen_api_docs.is_primitive('map[string]string'))
+        self.assertTrue(gen_api_docs.is_primitive('map[string]int'))
+
+        # Test k8s types
+        self.assertTrue(gen_api_docs.is_primitive('metav1.Time'))
+        self.assertTrue(gen_api_docs.is_primitive('corev1.PodSpec'))
+
+        # Test non-primitives
+        self.assertFalse(gen_api_docs.is_primitive('TestResourceSpec'))
+        self.assertFalse(gen_api_docs.is_primitive('CustomType'))
+        self.assertFalse(gen_api_docs.is_primitive('[]CustomType'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
…int the python code

FYI the type.go tests are not working, but I'm not sure how useful building a CRD from them will be since they import references from other projects, so the CRD available in the current _type.go is just a subset of the objects that make it up.

Using the generated CRD Yaml is a much better approach.