### PR TITLE
Activate API documentation generation for the new ACM 2.15 release

### DIFF
--- a/.github/workflows/generate-api-docs-release-2.15.yml
+++ b/.github/workflows/generate-api-docs-release-2.15.yml
@@ -1,0 +1,69 @@
+# .github/workflows/generate-api-docs.yml
+name: release-2.15, Generate and Commit API Docs
+
+# Controls when the action will run.
+on:
+  # Triggers the workflow at 00:05 UTC every day.
+  schedule:
+    - cron: '0 5 * * *'
+  
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Add permissions for the workflow
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  # This workflow contains a single job called "generate-docs"
+  generate-docs:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    env:
+      RELEASE_BRANCH: 'release-2.15'
+      BACKPLANE_BRANCH: 'backplane-2.10'
+      FORCE_DOWNLOAD: 'true'
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # 1. Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_BRANCH }}
+
+      # 2. Sets up Python environment for the make command
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11' # Use a recent Python 3 version
+
+      # 3. Runs the make command to install dependencies and generate the docs
+      - name: Generate API Documentation
+        run: RELEASE_BRANCH=${{ env.RELEASE_BRANCH }} BACKPLANE_BRANCH=${{ env.BACKPLANE_BRANCH }} FORCE_DOWNLOAD=${{ env.FORCE_DOWNLOAD }} make gen-api-docs-core
+        
+      # 4. Debug: Check state after generation
+      - name: Debug - Check state after generation
+        run: |
+          echo "Current branch: $(git branch --show-current)"
+          echo "Files in api-docs after generation:"
+          ls -la api-docs/ || echo "api-docs directory still doesn't exist"
+          echo "Git status after generation:"
+          git status
+          echo "Git diff:"
+          git diff --name-only || echo "No changes detected"
+          echo "Git diff with content:"
+          git diff || echo "No diff content"
+
+      # 5. Commits the changed files in the 'api-docs' directory
+      - name: Commit Documentation Changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "docs(api): Auto-generate API documentation for ${{ env.RELEASE_BRANCH }}"
+          commit_user_name: "GitHub Actions Bot"
+          commit_user_email: "github-actions[bot]@users.noreply.github.com"
+          commit_author: "GitHub Actions Bot <github-actions[bot]@users.noreply.github.com>"
+          file_pattern: api-docs/*.md
+          branch: ${{ env.RELEASE_BRANCH }}

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,8 @@ remove-core-crds:
 .PHONY: setup
 setup: deps
 	@mkdir -p api-docs
+	@printf "# This file ensures the .github directory is tracked by Git\n# Remove this file once you add workflow files to the directory" > api-docs/.gitkeep
+
 
 .PHONY: gen-api-docs
 gen-api-docs: setup

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository contains:
 The core API documentation, including all ACM CRDs and their detailed specifications, can be found in the [api-docs/README.md](./api-docs/README.md).
 <br>
 * [Release-2.14](https://github.com/stolostron/api-documentation/blob/release-2.14/api-docs/README.md)
-* [Release-2.15](https://github.com/stolostron/api-documentation/blob/release-2.15/api-docs/README.md)
+* [PRE-Release-2.15](https://github.com/stolostron/api-documentation/blob/release-2.15/api-docs/README.md)
 
 ## External ACM-Related API Documentation
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This repository contains:
 The core API documentation, including all ACM CRDs and their detailed specifications, can be found in the [api-docs/README.md](./api-docs/README.md).
 <br>
 * [Release-2.14](https://github.com/stolostron/api-documentation/blob/release-2.14/api-docs/README.md)
+* [Release-2.15](https://github.com/stolostron/api-documentation/blob/release-2.15/api-docs/README.md)
 
 ## External ACM-Related API Documentation
 

--- a/api-docs/.gitkeep
+++ b/api-docs/.gitkeep
@@ -1,2 +1,2 @@
 # This file ensures the .github directory is tracked by Git
-# Remove this file once you add workflow files to the directory 
+# Remove this file once you add workflow files to the directory


### PR DESCRIPTION
Additional:
* Fixes how we regenerate the api-docs directory in the `make setup`
* Release-2.15 runs 5min after release-2.14