### PR TITLE
feat: add stdio MCP server for searching ACM/MCE CRD API documentation

### DIFF
--- a/cmd/mcp-server.py
+++ b/cmd/mcp-server.py
@@ -20,7 +20,6 @@ import asyncio
 import json
 import urllib.request
 import urllib.error
-from functools import lru_cache
 
 import mcp.types as types
 from mcp.server import Server
@@ -38,6 +37,7 @@ DEFAULT_RELEASE = KNOWN_RELEASES[-1]
 RAW_BASE = "https://raw.githubusercontent.com/stolostron/api-documentation/{release}/api-docs/ai"
 
 # ── HTTP helpers ─────────────────────────────────────────────────────────────
+
 
 def _fetch_json(url: str) -> dict:
     """Fetch and parse JSON from a URL. Raises urllib.error.HTTPError on failure."""

--- a/cmd/mcp-server.py
+++ b/cmd/mcp-server.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""
+MCP stdio server for ACM/MCE API documentation.
+
+Fetches CRD schemas from published api-docs/ai/ output on GitHub.
+No local copy of generated docs required.
+
+Usage (Claude Code):
+  {
+    "mcpServers": {
+      "acm-api-docs": {
+        "command": "python3",
+        "args": ["/path/to/api-documentation/cmd/mcp-server.py"]
+      }
+    }
+  }
+"""
+
+import asyncio
+import json
+import urllib.request
+import urllib.error
+from functools import lru_cache
+
+import mcp.types as types
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+
+# ── Release configuration ────────────────────────────────────────────────────
+
+KNOWN_RELEASES = [
+    "release-2.14",
+    "release-2.15",
+    "release-2.16",
+]
+DEFAULT_RELEASE = KNOWN_RELEASES[-1]
+
+RAW_BASE = "https://raw.githubusercontent.com/stolostron/api-documentation/{release}/api-docs/ai"
+
+# ── HTTP helpers ─────────────────────────────────────────────────────────────
+
+def _fetch_json(url: str) -> dict:
+    """Fetch and parse JSON from a URL. Raises urllib.error.HTTPError on failure."""
+    with urllib.request.urlopen(url, timeout=15) as resp:
+        return json.loads(resp.read())
+
+
+def _fetch_text(url: str) -> str:
+    """Fetch raw text from a URL."""
+    with urllib.request.urlopen(url, timeout=15) as resp:
+        return resp.read().decode("utf-8")
+
+
+# Per-session in-memory cache: (release, kind|"index") -> data
+_cache: dict[tuple[str, str], object] = {}
+
+
+def _get_index(release: str) -> dict:
+    key = (release, "index")
+    if key not in _cache:
+        url = RAW_BASE.format(release=release) + "/index.json"
+        _cache[key] = _fetch_json(url)
+    return _cache[key]  # type: ignore[return-value]
+
+
+def _get_schema(release: str, kind: str) -> dict:
+    key = (release, kind)
+    if key not in _cache:
+        url = RAW_BASE.format(release=release) + f"/{kind}.json"
+        _cache[key] = _fetch_json(url)
+    return _cache[key]  # type: ignore[return-value]
+
+
+# ── Tool helpers ─────────────────────────────────────────────────────────────
+
+def _resolve_release(release: str | None) -> str:
+    return release if release in KNOWN_RELEASES else DEFAULT_RELEASE
+
+
+def _release_arg() -> dict:
+    return {
+        "release": {
+            "type": "string",
+            "description": (
+                f"Release branch name (e.g. 'release-2.16'). "
+                f"Defaults to '{DEFAULT_RELEASE}'. "
+                f"Known values: {', '.join(KNOWN_RELEASES)}."
+            ),
+        }
+    }
+
+
+# ── Server setup ─────────────────────────────────────────────────────────────
+
+server = Server("acm-api-docs")
+
+
+@server.list_tools()
+async def list_tools() -> list[types.Tool]:
+    return [
+        types.Tool(
+            name="list_releases",
+            description="List the known ACM/MCE release branches that have published API documentation.",
+            inputSchema={"type": "object", "properties": {}, "required": []},
+        ),
+        types.Tool(
+            name="list_crds",
+            description=(
+                "List all CRDs available in the API documentation index for a given release. "
+                "Returns kind, apiVersion, scope, and a short description for each CRD."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": _release_arg(),
+                "required": [],
+            },
+        ),
+        types.Tool(
+            name="get_crd_schema",
+            description=(
+                "Return the full JSON schema for a named CRD, including all spec and status fields "
+                "with types, descriptions, and validation constraints."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "kind": {
+                        "type": "string",
+                        "description": "The CRD kind name, e.g. 'ManagedCluster'.",
+                    },
+                    **_release_arg(),
+                },
+                "required": ["kind"],
+            },
+        ),
+        types.Tool(
+            name="get_crd_example",
+            description=(
+                "Return an example YAML manifest for a named CRD with representative field values."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "kind": {
+                        "type": "string",
+                        "description": "The CRD kind name, e.g. 'ManagedCluster'.",
+                    },
+                    **_release_arg(),
+                },
+                "required": ["kind"],
+            },
+        ),
+    ]
+
+
+@server.call_tool()
+async def call_tool(name: str, arguments: dict) -> list[types.TextContent]:
+    try:
+        result = _dispatch(name, arguments)
+    except urllib.error.HTTPError as e:
+        result = f"Error fetching data from GitHub: HTTP {e.code} — {e.reason}"
+    except urllib.error.URLError as e:
+        result = f"Network error: {e.reason}"
+    except KeyError as e:
+        result = f"Not found: {e}"
+    return [types.TextContent(type="text", text=result)]
+
+
+def _dispatch(name: str, args: dict) -> str:
+    if name == "list_releases":
+        return json.dumps({"releases": KNOWN_RELEASES, "default": DEFAULT_RELEASE}, indent=2)
+
+    release = _resolve_release(args.get("release"))
+
+    if name == "list_crds":
+        index = _get_index(release)
+        rows = [
+            {
+                "kind": c["kind"],
+                "apiVersion": c["apiVersion"],
+                "scope": c.get("scope", ""),
+                "description": c.get("description", ""),
+            }
+            for c in index["crds"]
+        ]
+        return json.dumps({"release": release, "count": len(rows), "crds": rows}, indent=2)
+
+    if name in ("get_crd_schema", "get_crd_example"):
+        kind = args.get("kind", "").strip()
+        if not kind:
+            raise KeyError("'kind' argument is required")
+
+        # Case-insensitive kind lookup via index
+        index = _get_index(release)
+        match = next(
+            (c for c in index["crds"] if c["kind"].lower() == kind.lower()),
+            None,
+        )
+        if match is None:
+            available = ", ".join(c["kind"] for c in index["crds"])
+            raise KeyError(
+                f"Kind '{kind}' not found in {release}. Available: {available}"
+            )
+
+        schema = _get_schema(release, match["kind"])
+
+        if name == "get_crd_schema":
+            return json.dumps(schema, indent=2)
+
+        # get_crd_example
+        example = schema.get("exampleYAML", "")
+        if not example:
+            return f"No example YAML available for {match['kind']} in {release}."
+        return example
+
+    raise KeyError(f"Unknown tool: {name}")
+
+
+# ── Entry point ──────────────────────────────────────────────────────────────
+
+async def main():
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(
+            read_stream,
+            write_stream,
+            server.create_initialization_options(),
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/cmd/mcp-server.py
+++ b/cmd/mcp-server.py
@@ -156,7 +156,7 @@ async def list_tools() -> list[types.Tool]:
 @server.call_tool()
 async def call_tool(name: str, arguments: dict) -> list[types.TextContent]:
     try:
-        result = _dispatch(name, arguments)
+        result = await asyncio.to_thread(_dispatch, name, arguments)
     except urllib.error.HTTPError as e:
         result = f"Error fetching data from GitHub: HTTP {e.code} — {e.reason}"
     except urllib.error.URLError as e:

--- a/plans/2026-04-08-mcp-server.md
+++ b/plans/2026-04-08-mcp-server.md
@@ -112,31 +112,122 @@ Prefer stdlib `urllib.request` for fetching to avoid adding a dependency beyond 
 
 ## Implementation
 
-### What was built
+### Files
 
-**`cmd/mcp-server.py`** — single-file Python, ~160 lines. All four planned tools implemented.
+| File | Lines | Description |
+|---|---|---|
+| `cmd/mcp-server.py` | 231 | Single-file stdio MCP server |
+| `plans/2026-04-08-mcp-server.md` | this file | Plan and implementation record |
+
+Makefile targets added to the existing `Makefile` (no new file):
+
+| Target | Command | Description |
+|---|---|---|
+| `install-mcp` | `python3 -m pip install --user mcp` | Install MCP Python SDK |
+| `run-mcp` | `python3 cmd/mcp-server.py` | Run server for manual testing |
+
+Both targets are listed under `make help`.
+
+---
+
+### Code structure
+
+```
+cmd/mcp-server.py
+├── Constants
+│   ├── KNOWN_RELEASES   — hard-coded list ["release-2.14", "release-2.15", "release-2.16"]
+│   ├── DEFAULT_RELEASE  — KNOWN_RELEASES[-1] (latest)
+│   └── RAW_BASE         — GitHub raw content URL template
+├── HTTP helpers
+│   ├── _fetch_json()    — urllib.request, 15s timeout, returns parsed dict
+│   ├── _fetch_text()    — urllib.request, 15s timeout, returns decoded str
+│   ├── _cache           — module-level dict keyed by (release, kind|"index")
+│   ├── _get_index()     — fetch/cache index.json for a release
+│   └── _get_schema()    — fetch/cache {Kind}.json for a release
+├── Tool helpers
+│   ├── _resolve_release() — validates release against KNOWN_RELEASES, falls back to DEFAULT_RELEASE
+│   └── _release_arg()     — returns reusable inputSchema fragment for the release parameter
+├── Server (mcp.Server("acm-api-docs"))
+│   ├── list_tools()     — registers all four tools with JSON Schema inputSchema
+│   ├── call_tool()      — top-level dispatcher; catches HTTPError, URLError, KeyError → text error
+│   └── _dispatch()      — synchronous per-tool logic
+└── Entry point — asyncio.run(main()) via stdio_server()
+```
+
+---
+
+### Tool implementations
+
+**`list_releases`**
+
+Returns `{"releases": [...], "default": "release-2.16"}`. No network call.
+
+**`list_crds`**
+
+Fetches `index.json` for the resolved release. Projects each CRD entry to `{kind, apiVersion, scope, description}`. Returns `{"release": ..., "count": N, "crds": [...]}`.
+
+**`get_crd_schema`**
+
+1. Resolves kind case-insensitively against `index.json` (e.g. `managedcluster` → `ManagedCluster`)
+2. Fetches `{Kind}.json`
+3. Returns the full JSON schema as a pretty-printed string
+
+Not-found error enumerates all available kinds so the caller can correct the name without a separate `list_crds` call.
+
+**`get_crd_example`**
+
+Same kind resolution as `get_crd_schema`. Returns `schema["exampleYAML"]` (a string). Returns a descriptive message if `exampleYAML` is absent or empty rather than raising.
+
+---
+
+### Caching
+
+`_cache` is a module-level `dict[tuple[str, str], object]`. The key is `(release, "index")` for the index and `(release, Kind)` for schemas. Populated lazily on first access per session; never invalidated (the server process is short-lived per MCP client session).
+
+---
+
+### Error handling
+
+`call_tool()` wraps `_dispatch()` in a try/except that catches:
+
+| Exception | Response |
+|---|---|
+| `urllib.error.HTTPError` | `"Error fetching data from GitHub: HTTP {code} — {reason}"` |
+| `urllib.error.URLError` | `"Network error: {reason}"` |
+| `KeyError` | `"Not found: {message}"` — used for missing kind, missing field, unknown tool |
+
+Errors are returned as `TextContent` strings, not raised — MCP clients handle them as normal tool results.
+
+---
 
 ### Deviations from plan
 
-- `list_releases` added as a first-class tool (was implicit in plan, not listed as a named tool)
-- `urllib.request` used for HTTP (as preferred); no `httpx` dependency
-- Case-insensitive kind lookup via index — `managedcluster` resolves to `ManagedCluster`; not-found error includes the full list of available kinds
+- `list_releases` promoted to a first-class named tool (plan listed it in the tools table but did not give it a separate description section)
+- `urllib.request` used exclusively — no `httpx` added (as preferred in plan)
+- `_fetch_text()` implemented but not called by any current tool — retained as it will be needed if a raw-YAML endpoint is added later
+- Case-insensitive kind lookup added (not in plan) — improves UX when callers use lowercase or mixed-case kind names
+
+---
 
 ### Alternatives considered and rejected
 
 **Go binary** — evaluated for easier distribution (single downloadable binary). Rejected: the server fetches from raw GitHub URLs at runtime; Go and Python reach those URLs equally well. A rewrite would add `go.mod` and Go toolchain to a Python-only repo with no benefit for the current audience. Revisit if there is demand to distribute this outside the repo.
 
-**`make sync` + local files** — fetch docs to disk first, serve locally. Rejected: adds steps (clone → sync → run) rather than removing them. Fetch-at-runtime is simpler.
+**`make sync` + local files** — fetch docs to disk first, serve locally. Rejected: adds steps (clone → sync → run) rather than removing them. Fetch-at-runtime is simpler and matches the goal of requiring no local copy of the generated docs.
+
+---
 
 ### Usage
 
 Install the dependency:
+
 ```sh
 make install-mcp
 # or: pip install --user mcp
 ```
 
-Add to `.claude/settings.json`:
+Add to `.claude/settings.json` (or equivalent for Cursor / Claude Desktop):
+
 ```json
 {
   "mcpServers": {
@@ -147,3 +238,19 @@ Add to `.claude/settings.json`:
   }
 }
 ```
+
+Test manually:
+
+```sh
+make run-mcp   # starts server on stdio; send JSON-RPC manually or use an MCP inspector
+```
+
+---
+
+### Verification
+
+- [x] `make lint` passes (flake8 — no unused imports, correct blank lines)
+- [x] `make install-mcp` installs `mcp` package via pip
+- [x] `make run-mcp` starts the server process without error
+- [x] `make help` lists `install-mcp` and `run-mcp` under the correct section
+- [ ] End-to-end test via Claude Code MCP client — connect and call all four tools against `release-2.16`

--- a/plans/2026-04-08-mcp-server.md
+++ b/plans/2026-04-08-mcp-server.md
@@ -202,7 +202,6 @@ Errors are returned as `TextContent` strings, not raised — MCP clients handle 
 
 ### Deviations from plan
 
-- `list_releases` promoted to a first-class named tool (plan listed it in the tools table but did not give it a separate description section)
 - `urllib.request` used exclusively — no `httpx` added (as preferred in plan)
 - `_fetch_text()` implemented but not called by any current tool — retained as it will be needed if a raw-YAML endpoint is added later
 - Case-insensitive kind lookup added (not in plan) — improves UX when callers use lowercase or mixed-case kind names

--- a/plans/2026-04-08-mcp-server.md
+++ b/plans/2026-04-08-mcp-server.md
@@ -1,0 +1,149 @@
+# MCP Server for ACM/MCE API Documentation
+
+**Date:** 2026-04-08  
+**Status:** Implemented
+
+---
+
+## Goal
+
+Create a minimal stdio MCP server that exposes ACM/MCE CRD schemas to any MCP-compatible client (Claude Code, Claude Desktop, Cursor, etc.) by fetching data from the published `api-docs/ai/` output on GitHub raw content URLs. The server lives in this repo and requires no local copy of the generated docs.
+
+---
+
+## Data Sources
+
+The generated `api-docs/ai/` directory is committed to each release branch (not `main`) and accessible via:
+
+```
+https://raw.githubusercontent.com/stolostron/api-documentation/{release}/api-docs/ai/index.json
+https://raw.githubusercontent.com/stolostron/api-documentation/{release}/api-docs/ai/{Kind}.json
+```
+
+Supported releases: `release-2.14`, `release-2.15`, `release-2.16` (and future branches).
+
+---
+
+## Plan
+
+### Phase 1 — Minimal stdio MCP server (Python)
+
+**File:** `cmd/mcp-server.py`
+
+Single-file implementation using the MCP Python SDK (`mcp`) over stdio transport.
+
+#### Tools to expose
+
+| Tool | Description | Args |
+|---|---|---|
+| `list_crds` | List all CRDs in the index with kind, apiVersion, scope, and description | `release` (optional, default: latest) |
+| `get_crd_schema` | Return full JSON schema for a named CRD | `kind` (required), `release` (optional) |
+| `get_crd_example` | Return example YAML for a named CRD | `kind` (required), `release` (optional) |
+| `list_releases` | Return known release branch names | — |
+
+#### Design decisions
+
+- **No local cache on startup** — fetch on first call per session, then cache in-memory for the session lifetime
+- **Release defaulting** — `list_releases` returns known branches; default is the latest known release
+- **Error handling** — return a descriptive error string (not raise) if GitHub fetch fails; caller can retry with a different release
+- **No auth** — raw GitHub content for public repos requires no token
+
+#### Release list
+
+Hard-coded initially: `["release-2.14", "release-2.15", "release-2.16"]`. New releases are added here when a new workflow is created.
+
+---
+
+### Phase 2 — Makefile integration
+
+Add targets:
+```makefile
+install-mcp    # pip install mcp dependency
+run-mcp        # python3 cmd/mcp-server.py (for manual testing)
+```
+
+---
+
+### Phase 3 — Claude Code config snippet
+
+Add a usage note to README (or a new `MCP.md`) showing the config block users add to `.claude/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "acm-api-docs": {
+      "command": "python3",
+      "args": ["/path/to/api-documentation/cmd/mcp-server.py"]
+    }
+  }
+}
+```
+
+---
+
+## File Layout
+
+```
+cmd/
+  gen-api-docs.py       (existing)
+  mcp-server.py         (new — Phase 1)
+```
+
+---
+
+## Dependencies
+
+- Python 3.11+  
+- `mcp` PyPI package (MCP Python SDK)  
+- `httpx` or `urllib.request` (stdlib) for HTTP fetching  
+
+Prefer stdlib `urllib.request` for fetching to avoid adding a dependency beyond `mcp`.
+
+---
+
+## Out of Scope (for now)
+
+- HTTP/SSE transport (stdio only for v1)
+- Search across fields within a CRD
+- Serving local `api-docs/ai/` as fallback
+- Auto-detecting the latest release from GitHub API
+
+---
+
+## Implementation
+
+### What was built
+
+**`cmd/mcp-server.py`** — single-file Python, ~160 lines. All four planned tools implemented.
+
+### Deviations from plan
+
+- `list_releases` added as a first-class tool (was implicit in plan, not listed as a named tool)
+- `urllib.request` used for HTTP (as preferred); no `httpx` dependency
+- Case-insensitive kind lookup via index — `managedcluster` resolves to `ManagedCluster`; not-found error includes the full list of available kinds
+
+### Alternatives considered and rejected
+
+**Go binary** — evaluated for easier distribution (single downloadable binary). Rejected: the server fetches from raw GitHub URLs at runtime; Go and Python reach those URLs equally well. A rewrite would add `go.mod` and Go toolchain to a Python-only repo with no benefit for the current audience. Revisit if there is demand to distribute this outside the repo.
+
+**`make sync` + local files** — fetch docs to disk first, serve locally. Rejected: adds steps (clone → sync → run) rather than removing them. Fetch-at-runtime is simpler.
+
+### Usage
+
+Install the dependency:
+```sh
+make install-mcp
+# or: pip install --user mcp
+```
+
+Add to `.claude/settings.json`:
+```json
+{
+  "mcpServers": {
+    "acm-api-docs": {
+      "command": "python3",
+      "args": ["/path/to/api-documentation/cmd/mcp-server.py"]
+    }
+  }
+}
+```


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h2 data-line="112" class="code-line" dir="auto" id="implementation" style="margin-top: 24px; font-weight: 600; margin-bottom: 16px; line-height: 1.25; font-size: 1.5em; padding-bottom: 0.3em; border-bottom: 1px solid rgba(255, 255, 255, 0.18); border-top-color: rgba(255, 255, 255, 0.18); border-right-color: rgba(255, 255, 255, 0.18); border-left-color: rgba(255, 255, 255, 0.18); position: relative; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Implementation</h2><h3 data-line="114" class="code-line" dir="auto" id="files" style="margin-top: 24px; font-weight: 600; margin-bottom: 16px; line-height: 1.25; font-size: 1.25em; position: relative; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Files</h3>
File | Lines | Description
-- | -- | --
cmd/mcp-server.py | 231 | Single-file stdio MCP server
plans/2026-04-08-mcp-server.md | this file | Plan and implementation record

<p data-line="198" class="code-line" dir="auto" style="margin-top: 0px; margin-bottom: 16px; position: relative; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Errors are returned as<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; color: rgb(136, 192, 208); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; font-size: 1em; line-height: 1.357em;">TextContent</code><span> </span>strings, not raised — MCP clients handle them as normal tool results.</p><hr data-line="200" class="code-line" dir="auto" style="border-width: 0px 0px 1px; border-top-style: initial; border-right-style: initial; border-left-style: initial; border-color: rgba(255, 255, 255, 0.18); border-image: initial; height: 1px; border-bottom-style: solid; position: relative; font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h3 data-line="202" class="code-line" dir="auto" id="deviations-from-plan" style="margin-top: 24px; font-weight: 600; margin-bottom: 16px; line-height: 1.25; font-size: 1.25em; position: relative; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Deviations from plan</h3><ul data-line="204" class="code-line" dir="auto" style="margin-top: 0px; margin-bottom: 0.7em; position: relative; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li data-line="204" class="code-line" dir="auto" style="position: relative;"><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; color: rgb(136, 192, 208); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; font-size: 1em; line-height: 1.357em;">list_releases</code><span> </span>promoted to a first-class named tool (plan listed it in the tools table but did not give it a separate description section)</li><li data-line="205" class="code-line" dir="auto" style="position: relative;"><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; color: rgb(136, 192, 208); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; font-size: 1em; line-height: 1.357em;">urllib.request</code><span> </span>used exclusively — no<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; color: rgb(136, 192, 208); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; font-size: 1em; line-height: 1.357em;">httpx</code><span> </span>added (as preferred in plan)</li><li data-line="206" class="code-line" dir="auto" style="position: relative;"><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; color: rgb(136, 192, 208); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; font-size: 1em; line-height: 1.357em;">_fetch_text()</code><span> </span>implemented but not called by any current tool — retained as it will be needed if a raw-YAML endpoint is added later</li><li data-line="207" class="code-line" dir="auto" style="position: relative;">Case-insensitive kind lookup added (not in plan) — improves UX when callers use lowercase or mixed-case kind names</li></ul><hr data-line="209" class="code-line" dir="auto" style="border-width: 0px 0px 1px; border-top-style: initial; border-right-style: initial; border-left-style: initial; border-color: rgba(255, 255, 255, 0.18); border-image: initial; height: 1px; border-bottom-style: solid; position: relative; font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h3 data-line="211" class="code-line" dir="auto" id="alternatives-considered-and-rejected" style="margin-top: 24px; font-weight: 600; margin-bottom: 16px; line-height: 1.25; font-size: 1.25em; position: relative; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Alternatives considered and rejected</h3><p data-line="213" class="code-line" dir="auto" style="margin-top: 0px; margin-bottom: 16px; position: relative; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Go binary</strong><span> </span>— evaluated for easier distribution (single downloadable binary). Rejected: the server fetches from raw GitHub URLs at runtime; Go and Python reach those URLs equally well. A rewrite would add<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; color: rgb(136, 192, 208); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; font-size: 1em; line-height: 1.357em;">go.mod</code><span> </span>and Go toolchain to a Python-only repo with no benefit for the current audience. Revisit if there is demand to distribute this outside the repo.</p><p data-line="215" class="code-line" dir="auto" style="margin-top: 0px; margin-bottom: 16px; position: relative; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; color: rgb(136, 192, 208); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; font-size: 1em; line-height: 1.357em;">make sync</code><span> </span>+ local files</strong><span> </span>— fetch docs to disk first, serve locally. Rejected: adds steps (clone → sync → run) rather than removing them. Fetch-at-runtime is simpler and matches the goal of requiring no local copy of the generated docs.</p><hr data-line="217" class="code-line" dir="auto" style="border-width: 0px 0px 1px; border-top-style: initial; border-right-style: initial; border-left-style: initial; border-color: rgba(255, 255, 255, 0.18); border-image: initial; height: 1px; border-bottom-style: solid; position: relative; font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h3 data-line="219" class="code-line" dir="auto" id="usage" style="margin-top: 24px; font-weight: 600; margin-bottom: 16px; line-height: 1.25; font-size: 1.25em; position: relative; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Usage</h3><p data-line="221" class="code-line" dir="auto" style="margin-top: 0px; margin-bottom: 16px; position: relative; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Install the dependency:</p><pre style="margin-top: 0px; background-color: rgba(10, 10, 10, 0.4); border-color: rgba(228, 228, 228, 0.92); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; padding: 16px; border-radius: 3px; overflow: auto; white-space: pre-wrap; color: rgba(228, 228, 228, 0.92); font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code data-line="223" class="code-line language-sh" dir="auto" style="font-family: Consolas, &quot;Courier New&quot;, monospace; color: rgba(228, 228, 228, 0.92); background: none; padding: 0px; border-radius: 4px; font-size: 1em; line-height: 1.357em; display: inline-block; tab-size: 4; position: relative;">make install-mcp
<span class="hljs-comment" style="color: rgb(87, 166, 74); font-style: italic;"># or: pip install --user mcp</span>
</code></pre><p data-line="228" class="code-line" dir="auto" style="margin-top: 0px; margin-bottom: 16px; position: relative; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Add to<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; color: rgb(136, 192, 208); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; font-size: 1em; line-height: 1.357em;">.claude/settings.json</code><span> </span>(or equivalent for Cursor / Claude Desktop):</p><pre style="margin-top: 0px; background-color: rgba(10, 10, 10, 0.4); border-color: rgba(228, 228, 228, 0.92); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; padding: 16px; border-radius: 3px; overflow: auto; white-space: pre-wrap; color: rgba(228, 228, 228, 0.92); font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code data-line="230" class="code-line language-json" dir="auto" style="font-family: Consolas, &quot;Courier New&quot;, monospace; color: rgba(228, 228, 228, 0.92); background: none; padding: 0px; border-radius: 4px; font-size: 1em; line-height: 1.357em; display: inline-block; tab-size: 4; position: relative;"><span class="hljs-punctuation">{</span>
  <span class="hljs-attr" style="color: rgb(156, 220, 254);">"mcpServers"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
    <span class="hljs-attr" style="color: rgb(156, 220, 254);">"acm-api-docs"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
      <span class="hljs-attr" style="color: rgb(156, 220, 254);">"command"</span><span class="hljs-punctuation">:</span> <span class="hljs-string" style="color: rgb(214, 157, 133);">"python3"</span><span class="hljs-punctuation">,</span>
      <span class="hljs-attr" style="color: rgb(156, 220, 254);">"args"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string" style="color: rgb(214, 157, 133);">"/path/to/api-documentation/cmd/mcp-server.py"</span><span class="hljs-punctuation">]</span>
    <span class="hljs-punctuation">}</span>
  <span class="hljs-punctuation">}</span>
<span class="hljs-punctuation">}</span>
</code></pre><p data-line="241" class="code-line" dir="auto" style="margin-top: 0px; margin-bottom: 16px; position: relative; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Test manually:</p><pre style="margin-top: 0px; background-color: rgba(10, 10, 10, 0.4); border-color: rgba(228, 228, 228, 0.92); border-style: none; border-width: 0px; border-image: none 100% / 1 / 0 stretch; padding: 16px; border-radius: 3px; overflow: auto; white-space: pre-wrap; color: rgba(228, 228, 228, 0.92); font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code data-line="243" class="code-line language-sh" dir="auto" style="font-family: Consolas, &quot;Courier New&quot;, monospace; color: rgba(228, 228, 228, 0.92); background: none; padding: 0px; border-radius: 4px; font-size: 1em; line-height: 1.357em; display: inline-block; tab-size: 4; position: relative;">make run-mcp   <span class="hljs-comment" style="color: rgb(87, 166, 74); font-style: italic;"># starts server on stdio; send JSON-RPC manually or use an MCP inspector</span>
</code></pre><hr data-line="247" class="code-line" dir="auto" style="border-width: 0px 0px 1px; border-top-style: initial; border-right-style: initial; border-left-style: initial; border-color: rgba(255, 255, 255, 0.18); border-image: initial; height: 1px; border-bottom-style: solid; position: relative; font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h3 data-line="249" class="code-line" dir="auto" id="verification" style="margin-top: 24px; font-weight: 600; margin-bottom: 16px; line-height: 1.25; font-size: 1.25em; position: relative; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Verification</h3><ul data-line="251" class="code-line" dir="auto" style="margin-top: 0px; margin-bottom: 0.7em; position: relative; color: rgba(228, 228, 228, 0.92); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li data-line="251" class="code-line" dir="auto" style="position: relative;">[x]<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; color: rgb(136, 192, 208); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; font-size: 1em; line-height: 1.357em;">make lint</code><span> </span>passes (flake8 — no unused imports, correct blank lines)</li><li data-line="252" class="code-line" dir="auto" style="position: relative;">[x]<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; color: rgb(136, 192, 208); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; font-size: 1em; line-height: 1.357em;">make install-mcp</code><span> </span>installs<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; color: rgb(136, 192, 208); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; font-size: 1em; line-height: 1.357em;">mcp</code><span> </span>package via pip</li><li data-line="253" class="code-line" dir="auto" style="position: relative;">[x]<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; color: rgb(136, 192, 208); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; font-size: 1em; line-height: 1.357em;">make run-mcp</code><span> </span>starts the server process without error</li><li data-line="254" class="code-line" dir="auto" style="position: relative;">[x]<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; color: rgb(136, 192, 208); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; font-size: 1em; line-height: 1.357em;">make help</code><span> </span>lists<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; color: rgb(136, 192, 208); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; font-size: 1em; line-height: 1.357em;">install-mcp</code><span> </span>and<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; color: rgb(136, 192, 208); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; font-size: 1em; line-height: 1.357em;">run-mcp</code><span> </span>under the correct section</li><li data-line="255" class="code-line" dir="auto" style="position: relative;">[ ] End-to-end test via Claude Code MCP client — connect and call all four tools against<span> </span><code style="font-family: Consolas, &quot;Courier New&quot;, monospace; color: rgb(136, 192, 208); background-color: rgba(255, 255, 255, 0.1); padding: 1px 3px; border-radius: 4px; font-size: 1em; line-height: 1.357em;">release-2.16</code></li></ul><!--EndFragment-->
</body>
</html>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an MCP server exposing ACM/MCE CRD schemas and examples.
  * Four tools available: list releases, list CRDs, retrieve CRD schema, and retrieve CRD examples.
  * Built-in caching for improved performance and case-insensitive CRD lookups.
  * Enhanced error handling with descriptive messages for common failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->