### PR TITLE
fix(deps): security audit 2026-04-15 — all dependencies clean, no CVEs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Direct Python dependencies for api-documentation
-# Last security audit: 2026-04-13 — pip-audit clean, all packages at latest stable release
+# Last security audit: 2026-04-15 — pip-audit clean, all packages at latest stable release
 # PyYAML: used by cmd/gen-api-docs.py for CRD YAML parsing
 PyYAML==6.0.3
 # flake8: used for Python linting (make lint)


### PR DESCRIPTION
## Security audit summary

Routine security audit run on 2026-04-15.

### CVEs resolved

None — audit was clean.

The prior CVE pinned in the file (CVE-2026-39892 → `cryptography==46.0.7`) remains resolved.

### Dependencies audited

| Package | Current version | Latest stable | Status |
|---------|----------------|---------------|--------|
| PyYAML | 6.0.3 | 6.0.3 | ✅ Latest, clean |
| flake8 | 7.3.0 | 7.3.0 | ✅ Latest, clean |
| mcp | 1.27.0 | 1.27.0 | ✅ Latest, clean |
| cryptography | 46.0.7 | 46.0.7 | ✅ Latest, clean (resolves CVE-2026-39892) |

### Verification

- [x] CVE scan: `pip-audit -r requirements.txt` → **No known vulnerabilities found**
- [x] Lint: `make lint` → passing (flake8, 0 errors)
- [x] Tests: `make test` → passing (39 tests: CRD import, Helm template removal, AI output)

### Notes on full-environment scan

Running `pip-audit` against the full Python environment (not scoped to this project's `requirements.txt`) surfaced CVEs in `fastmcp`, `pip`, `uv`, and `diskcache`. These packages are **not** dependencies of this project and are not present in `requirements.txt` — they are unrelated system/environment packages installed elsewhere in the build container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security audit documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->