### PR TITLE
fix(deps): security audit 2026-04-27 — update cryptography to 47.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Direct Python dependencies for api-documentation
-# Last security audit: 2026-04-13 — pip-audit clean, all packages at latest stable release
+# Last security audit: 2026-04-27 — pip-audit clean, all packages at latest stable release
 # PyYAML: used by cmd/gen-api-docs.py for CRD YAML parsing
 PyYAML==6.0.3
 # flake8: used for Python linting (make lint)
@@ -7,4 +7,4 @@ flake8==7.3.0
 # mcp: used by cmd/mcp-server.py (MCP stdio server)
 mcp==1.27.0
 # cryptography: transitive dep via mcp->pyjwt[crypto]; pinned to resolve CVE-2026-39892
-cryptography==46.0.7
+cryptography==47.0.0


### PR DESCRIPTION
## Security audit summary

Performed a full Python dependency security audit on 2026-04-27.

### CVEs resolved

None — pip-audit scan was clean before and after the update.

### Dependencies updated

| Package | Before | After | Tool |
|---------|--------|-------|------|
| cryptography | 46.0.7 | 47.0.0 | pip |

All other direct dependencies (PyYAML 6.0.3, flake8 7.3.0, mcp 1.27.0) are already at latest stable.

### Verification

- [x] CVE scan: clean (pip-audit, both before and after update)
- [x] Lint: passing (`make lint` — flake8 7.3.0, zero errors)
- [x] Tests: passing (`make test` — 39 tests across CRD import, Helm template removal, and AI output suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a pinned security dependency to a newer, secure release.
  * Refreshed the project's last security audit date.
  * Routine low-risk maintenance to keep dependency pins current and reduce potential vulnerabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->