### PR TITLE
fix(deps): update Python dependencies and resolve security vulnerabilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,8 @@ PyYAML==6.0.3
 flake8==7.3.0
 # mcp: used by cmd/mcp-server.py (MCP stdio server)
 mcp==1.27.1
+# TODO(PYSEC-2025-183): pyjwt (transitive via mcp) — disputed by PyJWT upstream; no fix version available as of 2026-05-20.
+# The vulnerability describes weak encryption due to short key lengths, which is an application-level concern.
+# Monitor https://github.com/jpadilla/pyjwt for a fix release.
 # cryptography: transitive dep via mcp->pyjwt[crypto]; pinned for security; updated 2026-05-05
 cryptography==48.0.0


### PR DESCRIPTION
## Security audit summary

### CVEs found
| CVE ID | Package | Severity | Fixed in | Status |
|--------|---------|----------|----------|--------|
| PYSEC-2025-183 | pyjwt (transitive via mcp) | Unknown | N/A | No fix available — documented |

### Details
PYSEC-2025-183 affects pyjwt and describes weak encryption due to short key lengths chosen by the application. This finding is **disputed by the PyJWT upstream** as an application-level concern rather than a library defect. No fix version exists — pyjwt 2.12.1 is already the latest release.

Per audit policy, a `# TODO(PYSEC-2025-183)` comment has been added at the dependency site in `requirements.txt` to track this until a fix is released.

### Dependencies updated
All direct dependencies are already at their latest stable versions:
- PyYAML==6.0.3 (latest)
- flake8==7.3.0 (latest)
- mcp==1.27.1 (latest)
- cryptography==48.0.0 (latest)

### Verification
- [x] pip-audit: 1 finding (PYSEC-2025-183, no fix available, documented)
- [x] Lint (flake8): passing
- [x] Tests (test_crd_import, test_helm_template_removal, test_ai_output): passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a maintenance note to track a future security update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->