### PR TITLE
fix: tighten branch-pattern regex to reject unrelated branches

### DIFF
--- a/.github/workflows/auto-merge-deps.yaml
+++ b/.github/workflows/auto-merge-deps.yaml
@@ -46,7 +46,7 @@ jobs:
           # "MERGEABLE" moments later once GitHub finishes the check - this
           # is expected and not something to special-case here.
           prs=$(gh pr list --state open --base main --limit 100 --json number,title,url,author,headRefName,headRefOid,statusCheckRollup,mergeable,labels --jq '
-            def branch_match: .headRefName | test("^(fix|build|deps)/(deps-)?(go|python)(-deps)?(-update)?-");
+            def branch_match: .headRefName | test("^(fix|build|deps)/(deps-(go|python)(-update)?-|(go|python)(-deps|-update)-)");
             .[] | select(
               (.author.login == "swarmer-jnpacker[bot]" or .author.login == "app/swarmer-jnpacker") and
               (


### PR DESCRIPTION
CodeRabbit caught a real correctness bug on `OpenShift-Fleet/agentic-sdlc` PR #87: making the `deps-` prefix, `-deps` suffix, and `-update` suffix all independently optional means the regex degenerates to just `^(fix|build|deps)/(go|python)-`, which matches almost any branch starting with a trusted prefix and language — e.g. `fix/go-unrelated-change` or `build/python-totally-different` both incorrectly matched.

**New pattern:** `^(fix|build|deps)/(deps-(go|python)(-update)?-|(go|python)(-deps|-update)-)` requires at least one of the `deps-`/`-deps`/`-update` markers to be present (mandatory literal in one of the two alternatives), instead of allowing all three to be absent simultaneously.

Verified against all 4 known real formats (still match) plus the two false-positive cases CodeRabbit identified (now correctly rejected) with a local jq test matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update handling by recognizing supported branch naming patterns.
  * Preserved compatibility with existing fix, build, and dependency branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->