### PR TITLE
ci(auto-merge-deps): match deps/package-update-* branch naming

### DIFF
--- a/.github/workflows/auto-merge-deps.yaml
+++ b/.github/workflows/auto-merge-deps.yaml
@@ -46,7 +46,7 @@ jobs:
           # "MERGEABLE" moments later once GitHub finishes the check - this
           # is expected and not something to special-case here.
           prs=$(gh pr list --state open --base main --limit 100 --json number,title,url,author,headRefName,headRefOid,statusCheckRollup,mergeable,labels --jq '
-            def branch_match: .headRefName | test("^(fix|build|deps)/(deps-(go|python)(-update)?-|(go|python)(-deps|-update)-)");
+            def branch_match: .headRefName | test("^((fix|build|deps)/(deps-(go|python)(-update)?-|(go|python)(-deps|-update)-)|deps/package-update-)");
             .[] | select(
               (.author.login == "swarmer-jnpacker[bot]" or .author.login == "app/swarmer-jnpacker") and
               (
@@ -160,7 +160,8 @@ jobs:
             echo ""
             echo "Checked for dependency PRs authored by swarmer-jnpacker[bot] that either match"
             echo "branches matching \`(fix|build|deps)/[deps-]{go,python}[-deps][-update]-*\`"
-            echo "(the deps- prefix, -deps suffix, and -update suffix are each optional), or"
+            echo "(the deps- prefix, -deps suffix, and -update suffix are each optional),"
+            echo "\`deps/package-update-*\` (current swarm-deps-agent naming), or"
             echo "carry the \`automated-update\` label, and have:"
             echo "- All status checks passing (SUCCESS)"
             echo "- Mergeable state (no conflicts)"


### PR DESCRIPTION
The swarm-deps-agent bot now creates dependency-update branches named `deps/package-update-<date>` (no go/python language segment). Extends `branch_match` in the auto-merge-deps workflow to also accept this bare prefix alongside the existing `(fix|build|deps)/(deps-(go|python)(-update)?-|(go|python)(-deps|-update)-)` patterns.